### PR TITLE
Named analyzers and better error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,26 +22,34 @@ module BadCodeAnalyzer
 open FSharp.Analyzers.SDK
 
 [<Analyzer>]
-let badCodeAnalyzer : Analyzer = 
-  fun (context: Context) = 
+let badCodeAnalyzer : Analyzer =
+  fun (context: Context) ->
     // inspect context to determine the error/warning messages
     [   ]
 ```
-Notice how we expose the function `BadCodeAnalyzer.badCodeAnalyzer` with an attribute `[<Analyzer>]` that allows the SDK to detect the function. The input `Context` is a record that contains information about a single F# file such as the typed AST, the AST, the file content, the file name and more. The SDK runs this function against all files of a project during editing. The output messages that come out of the function are eventually used by Ionide to highlight the inspected code as a warning or error depending on the `Severity` level of each message. 
+Notice how we expose the function `BadCodeAnalyzer.badCodeAnalyzer` with an attribute `[<Analyzer>]` that allows the SDK to detect the function. The input `Context` is a record that contains information about a single F# file such as the typed AST, the AST, the file content, the file name and more. The SDK runs this function against all files of a project during editing. The output messages that come out of the function are eventually used by Ionide to highlight the inspected code as a warning or error depending on the `Severity` level of each message.
 
+Analyzers can also be named which allows for better logging if something went wrong while using the SDK from Ionide:
+```fs
+[<Analyzer "BadCodeAnalyzer">]
+let badCodeAnalyzer : Analyzer =
+  fun (context: Context) ->
+    // inspect context to determine the error/warning messages
+    [   ]
+```
 ### Analyzer Requirements
 
 Analyzers are .NET core class libraries and they are distributed as such. However, since the SDK relies on dynamically loading the analyzers during runtime, there are some requirements to get them to work properly:
  - The analyzer class library has to target the `netcoreapp2.0` framework
  - The analyzer has to reference the latest `FSharp.Analyzers.SDK` (at least the version used by FsAutoComplete which is subsequently used by Ionide)
- 
+
 ### Packaging and Distribution
 
 Since analyzers are just .NET core libraries, you can distribute them to the nuget registry just like you would with a normal .NET package. Simply run `dotnet pack --configuration Release` against the analyzer project to get a nuget package and publish it with
 
 ```
 dotnet nuget push {NugetPackageFullPath} -s nuget.org -k {NugetApiKey}
-``` 
+```
 
 However, the story is different and slightly more complicated when your analyzer package has third-party dependencies also coming from nuget. Since the SDK dynamically loads the package assemblies (`.dll` files), the assemblies of the dependencies has be there *next* to the main assembly of the analyzer. Using `dotnet pack` will **not** include these dependencies into the output Nuget package. More specifically, the `./lib/netcoreapp2.0` directory of the nuget package must have all the required assemblies, also those from third-party packages. In order to package the analyzer properly with all the assemblies, you need to take the output you get from running:
 ```
@@ -64,7 +72,7 @@ Target.create "PackAnalyzer" (fun _ ->
             sprintf "/p:PackageReleaseNotes=\"%s\"" (String.concat "\n" releaseNotes.Notes)
             sprintf "--output %s" (__SOURCE_DIRECTORY__ </> "dist")
         ]
-    
+
     // create initial nuget package
     let exitCode = Shell.Exec("dotnet", String.concat " " args, analyzerProject)
     if exitCode <> 0 then

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+### 0.4.0 - 08.03.2020
+
+* Allow for optional named analyzers via the attribute `[<Analyzer("AnalyzerName")>]`
+* Add ability to get exact errors from running each individial analyzer
+
 ### 0.3.1 - 28.02.2020
 
 * Update FCS version to 34.1.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 ### 0.4.0 - 08.03.2020
 
 * Allow for optional named analyzers via the attribute `[<Analyzer("AnalyzerName")>]`
-* Add ability to get exact errors from running each individial analyzer
+* Add ability to get exact errors from running each individual analyzer
 
 ### 0.3.1 - 28.02.2020
 

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -2,7 +2,7 @@ source https://api.nuget.org/v3/index.json
 source ./lib
 
 nuget FSharp.Core ~> 4.5
-nuget FSharp.Compiler.Service 34.1.0
+nuget FSharp.Compiler.Service 34.1.1
 nuget Argu
 nuget Glob
 

--- a/paket.lock
+++ b/paket.lock
@@ -3,7 +3,7 @@ NUGET
     Argu (6.0)
       FSharp.Core (>= 4.3.2) - restriction: >= netstandard2.0
       System.Configuration.ConfigurationManager (>= 4.4) - restriction: >= netstandard2.0
-    FSharp.Compiler.Service (34.1)
+    FSharp.Compiler.Service (34.1.1)
       FSharp.Core (>= 4.6.2) - restriction: || (>= net461) (>= netstandard2.0)
       System.Buffers (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
       System.Collections.Immutable (>= 1.5) - restriction: || (>= net461) (>= netstandard2.0)
@@ -632,24 +632,24 @@ NUGET
       FSharp.Core (>= 4.6.2) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.NETFramework.ReferenceAssemblies (>= 1.0) - restriction: || (>= net461) (>= netstandard2.0)
   remote: paket-files/github.com/fsharp/FsAutoComplete/bin/pkgs
-    ProjectSystem (0.40.0)
+    ProjectSystem (0.40.1)
       Dotnet.ProjInfo (>= 0.38) - restriction: || (>= net461) (>= netstandard2.0)
       Dotnet.ProjInfo.Workspace.FCS (>= 0.38) - restriction: || (>= net461) (>= netstandard2.0)
-      FSharp.Compiler.Service (>= 34.1) - restriction: || (>= net461) (>= netstandard2.0)
+      FSharp.Compiler.Service (>= 34.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.NETFramework.ReferenceAssemblies (>= 1.0) - restriction: || (>= net461) (>= netstandard2.0)
       Newtonsoft.Json (>= 12.0.3) - restriction: || (>= net461) (>= netstandard2.0)
       Sln (>= 0.3) - restriction: || (>= net461) (>= netstandard2.0)
 GIT
   remote: https://github.com/fsharp/FsAutoComplete.git
-     (d849d7200382f5da2c0179c5a555783644cb7c0b)
+     (8fb00089e5af75bbdf1280e6cbfe2d0e25caea5c)
       build: build.cmd
       path: /bin/pkgs/
       os: win
-     (d849d7200382f5da2c0179c5a555783644cb7c0b)
+     (8fb00089e5af75bbdf1280e6cbfe2d0e25caea5c)
       build: build.sh
       path: /bin/pkgs/
       os: osx
-     (d849d7200382f5da2c0179c5a555783644cb7c0b)
+     (8fb00089e5af75bbdf1280e6cbfe2d0e25caea5c)
       build: build.sh
       path: /bin/pkgs/
       os: linux

--- a/samples/OptionAnalyzer/Library.fs
+++ b/samples/OptionAnalyzer/Library.fs
@@ -116,7 +116,7 @@ let notUsed() =
     let option : Option<int> = None
     option.Value
 
-[<Analyzer>]
+[<Analyzer "OptionAnalyzer">]
 let optionValueAnalyzer : Analyzer =
     fun ctx ->
         let state = ResizeArray<range>()
@@ -133,6 +133,5 @@ let optionValueAnalyzer : Analyzer =
               Severity = Warning
               Range = r
               Fixes = []}
-
         )
         |> Seq.toList

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fs
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fs
@@ -4,10 +4,14 @@ open System
 open FSharp.Compiler
 open FSharp.Compiler.Ast
 open FSharp.Compiler.SourceCodeServices
+open System.Runtime.InteropServices
 
 /// Marks an analyzer for scanning
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property ||| AttributeTargets.Field)>]
-type AnalyzerAttribute() = inherit Attribute()
+type AnalyzerAttribute([<Optional; DefaultParameterValue "Analyzer">] name: string) =
+  inherit Attribute()
+
+  member _.Name = name
 
 type Context =
     { FileName: string


### PR DESCRIPTION
When the SDK runs analyzers, it swallows all errors making it impossible for FSAC to know which analyzer is problematic and makes troubleshooting harder. This PR addresses this issue by allowing the analyzers to be (optionally) named via the attribute like this `[<Analuzer "AnalyzerName">]`. I added a new function to run the analyzers of this signature:
```fs
val runAnalyzersSafely : Context -> AnalysisResult list
```
Where each `AnalysisResult` is the result of each registered analyzer and is defined as follows:
```fs
type AnalysisResult = {
  AnalyzerName : string
  Output : Result<Message list, exn>
}
```
This way, we will be able to identify which analyzer wasn't able to run successfully and why (cc @baronfel) 

This is also preparation for fixing #8 which required the analyzers to be named. 