### PR TITLE
bump to fcs 37 and associated DPI dependencies

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -160,7 +160,11 @@ Target.create "Push" (fun _ ->
     Paket.push (fun p -> { p with WorkingDir = buildDir; ApiKey = key }))
 
 Target.create "RunSample" (fun _ ->
-    let args = @"-p src\FSharp.Analyzers.Cli -- --project .\samples\OptionAnalyzer\OptionAnalyzer.fsproj --analyzers-path .\samples\OptionAnalyzer\bin\Release --verbose"
+    let projectPath = Path.combine "src" "FSharp.Analyzers.Cli"
+    let optionAnalyzerDir = Path.combine (Path.combine __SOURCE_DIRECTORY__ "samples") "OptionAnalyzer"
+    let optionAnalyzerProjPath = Path.combine optionAnalyzerDir "OptionAnalyzer.fsproj"
+    let analyzersPath = Path.combine (Path.combine optionAnalyzerDir "bin") "Release"
+    let args = sprintf "-p %s -- --project %s --analyzers-path %s --verbose" projectPath optionAnalyzerProjPath analyzersPath
 
     DotNet.exec id "run" args
     |> ignore

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,7 +1,8 @@
 source https://api.nuget.org/v3/index.json
 
 nuget FSharp.Core ~> 4.5
-nuget FSharp.Compiler.Service ~> 36.0
+nuget FSharp.Compiler.Service ~> 37.0
+nuget Dotnet.ProjInfo.Workspace.FCS
 nuget Argu
 nuget Glob
 

--- a/paket.lock
+++ b/paket.lock
@@ -3,22 +3,25 @@ NUGET
     Argu (6.1.1)
       FSharp.Core (>= 4.3.2) - restriction: >= netstandard2.0
       System.Configuration.ConfigurationManager (>= 4.4) - restriction: >= netstandard2.0
-    Dotnet.ProjInfo (0.42.1) - restriction: || (>= net461) (>= netstandard2.0)
+    Dotnet.ProjInfo (0.44) - restriction: || (>= net461) (>= netstandard2.0)
       FSharp.Core (>= 4.6.2) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.NETFramework.ReferenceAssemblies (>= 1.0) - restriction: || (>= net461) (>= netstandard2.0)
       System.ValueTuple (>= 4.4) - restriction: || (>= net461) (>= netstandard2.0)
-    Dotnet.ProjInfo.Workspace (0.42.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Dotnet.ProjInfo (>= 0.42.1) - restriction: || (>= net461) (>= netstandard2.0)
+    Dotnet.ProjInfo.Workspace (0.44) - restriction: || (>= net461) (>= netstandard2.0)
+      Dotnet.ProjInfo (>= 0.44) - restriction: || (>= net461) (>= netstandard2.0)
       FSharp.Core (>= 4.6.2) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.NETFramework.ReferenceAssemblies (>= 1.0) - restriction: || (>= net461) (>= netstandard2.0)
       Sln (>= 0.3) - restriction: || (>= net461) (>= netstandard2.0)
-    Dotnet.ProjInfo.Workspace.FCS (0.41.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Dotnet.ProjInfo.Workspace (>= 0.41.1) - restriction: || (>= net461) (>= netstandard2.0)
-      FSharp.Compiler.Service (>= 35.0) - restriction: || (>= net461) (>= netstandard2.0)
+    Dotnet.ProjInfo.Workspace.FCS (0.44)
+      Dotnet.ProjInfo.Workspace (>= 0.44) - restriction: || (>= net461) (>= netstandard2.0)
+      FSharp.Compiler.Service (>= 37.0) - restriction: || (>= net461) (>= netstandard2.0)
       FSharp.Core (>= 4.6.2) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.NETFramework.ReferenceAssemblies (>= 1.0) - restriction: || (>= net461) (>= netstandard2.0)
-    FSharp.Compiler.Service (36.0.3)
+    FSharp.Compiler.Service (37.0)
       FSharp.Core (>= 4.6.2) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.Build.Framework (>= 16.6) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.Build.Tasks.Core (>= 16.6) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.Build.Utilities.Core (>= 16.6) - restriction: || (>= net461) (>= netstandard2.0)
       System.Buffers (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
       System.Collections.Immutable (>= 1.5) - restriction: || (>= net461) (>= netstandard2.0)
       System.Memory (>= 4.5.3) - restriction: || (>= net461) (>= netstandard2.0)
@@ -39,10 +42,31 @@ NUGET
       System.Text.Json (>= 4.7) - restriction: && (>= netcoreapp2.0) (< netcoreapp3.0)
     Microsoft.Bcl.AsyncInterfaces (1.1.1) - restriction: || (&& (>= monoandroid) (>= netcoreapp2.0)) (&& (>= monotouch) (>= netcoreapp2.0)) (&& (>= net461) (>= netcoreapp2.0)) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (>= netcoreapp2.0) (>= uap10.1)) (&& (>= netcoreapp2.0) (>= xamarinios)) (&& (>= netcoreapp2.0) (>= xamarinmac)) (&& (>= netcoreapp2.0) (>= xamarintvos)) (&& (>= netcoreapp2.0) (>= xamarinwatchos)) (&& (>= netcoreapp2.1) (< netcoreapp3.0))
       System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (>= net461) (&& (< netcoreapp2.1) (>= netstandard2.0)) (>= netstandard2.1)
-    Microsoft.DotNet.PlatformAbstractions (3.1.5) - restriction: >= netcoreapp2.0
-    Microsoft.Extensions.DependencyModel (3.1.5) - restriction: >= netcoreapp2.0
+    Microsoft.Build.Framework (16.6) - restriction: || (>= net461) (>= netstandard2.0)
+      System.Security.Permissions (>= 4.7) - restriction: && (< net472) (>= netstandard2.0)
+    Microsoft.Build.Tasks.Core (16.6) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.Build.Framework (>= 16.6) - restriction: >= netstandard2.0
+      Microsoft.Build.Utilities.Core (>= 16.6) - restriction: >= netstandard2.0
+      Microsoft.VisualStudio.Setup.Configuration.Interop (>= 1.16.30) - restriction: >= net472
+      Microsoft.Win32.Registry (>= 4.3) - restriction: && (< net472) (>= netstandard2.0)
+      System.CodeDom (>= 4.4) - restriction: && (< net472) (>= netstandard2.0)
+      System.Collections.Immutable (>= 1.5) - restriction: >= netstandard2.0
+      System.Reflection.Metadata (>= 1.6) - restriction: && (< net472) (>= netstandard2.0)
+      System.Reflection.TypeExtensions (>= 4.1) - restriction: && (< net472) (>= netstandard2.0)
+      System.Resources.Extensions (>= 4.6) - restriction: >= netstandard2.0
+      System.Security.Permissions (>= 4.7) - restriction: && (< net472) (>= netstandard2.0)
+      System.Threading.Tasks.Dataflow (>= 4.9) - restriction: >= netstandard2.0
+    Microsoft.Build.Utilities.Core (16.6) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.Build.Framework (>= 16.6) - restriction: >= netstandard2.0
+      Microsoft.VisualStudio.Setup.Configuration.Interop (>= 1.16.30) - restriction: >= net472
+      Microsoft.Win32.Registry (>= 4.3) - restriction: && (< net472) (>= netstandard2.0)
+      System.Collections.Immutable (>= 1.5) - restriction: >= netstandard2.0
+      System.Security.Permissions (>= 4.7) - restriction: && (< net472) (>= netstandard2.0)
+      System.Text.Encoding.CodePages (>= 4.0.1) - restriction: && (< net472) (>= netstandard2.0)
+    Microsoft.DotNet.PlatformAbstractions (3.1.6) - restriction: >= netcoreapp2.0
+    Microsoft.Extensions.DependencyModel (3.1.6) - restriction: >= netcoreapp2.0
       System.Text.Json (>= 4.7.2) - restriction: && (< net451) (>= netstandard2.0)
-    Microsoft.NETCore.Platforms (3.1.1) - restriction: || (&& (< monoandroid) (< net40) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< monoandroid) (< net40) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= net46) (< netstandard1.4)) (&& (< net40) (>= net461) (< netstandard2.0)) (&& (< net40) (< netstandard1.0) (>= netstandard1.3) (< portable-net45+win8)) (&& (< net40) (< netstandard1.0) (>= netstandard1.3) (< win8)) (&& (< net40) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< net40) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.3) (< portable-net45+win8+wpa81)) (&& (< net40) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (>= net461) (>= netcoreapp2.1)) (>= netcoreapp2.0) (&& (>= netcoreapp2.1) (< netcoreapp3.0)) (&& (>= netcoreapp5.0) (< netstandard1.2)) (&& (>= netcoreapp5.0) (< netstandard1.4)) (&& (>= netcoreapp5.0) (< netstandard1.5)) (&& (>= netcoreapp5.0) (< netstandard1.6)) (&& (>= netcoreapp5.0) (< netstandard2.0)) (&& (< netstandard1.0) (>= netstandard1.3) (>= win8)) (&& (>= netstandard1.3) (>= wp8)) (&& (< netstandard1.5) (>= uap10.0)) (>= uap10.1)
+    Microsoft.NETCore.Platforms (3.1.2) - restriction: || (&& (>= monoandroid) (>= netcoreapp2.1)) (&& (< monoandroid) (< net40) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< monoandroid) (< net40) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (>= monotouch) (>= netcoreapp2.1)) (&& (< net40) (>= net46) (< netstandard1.4)) (&& (< net40) (>= net461) (< netstandard2.0)) (&& (< net40) (< netstandard1.0) (>= netstandard1.3) (< portable-net45+win8)) (&& (< net40) (< netstandard1.0) (>= netstandard1.3) (< win8)) (&& (< net40) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< net40) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.3) (< portable-net45+win8+wpa81)) (&& (< net40) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (>= net461) (>= netcoreapp2.1)) (>= netcoreapp2.0) (&& (>= netcoreapp2.1) (>= xamarinios)) (&& (>= netcoreapp2.1) (>= xamarinmac)) (&& (>= netcoreapp2.1) (>= xamarintvos)) (&& (>= netcoreapp2.1) (>= xamarinwatchos)) (&& (>= netcoreapp5.0) (< netstandard1.2)) (&& (>= netcoreapp5.0) (< netstandard1.4)) (&& (>= netcoreapp5.0) (< netstandard1.5)) (&& (>= netcoreapp5.0) (< netstandard1.6)) (&& (>= netcoreapp5.0) (< netstandard2.0)) (&& (< netstandard1.0) (>= netstandard1.3) (>= win8)) (&& (>= netstandard1.3) (>= wp8)) (&& (< netstandard1.5) (>= uap10.0)) (>= uap10.1)
     Microsoft.NETCore.Targets (3.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.1) (>= netstandard1.3) (< win8)) (&& (< monoandroid) (< net40) (< netstandard1.1) (>= netstandard1.4) (< win8)) (&& (< monoandroid) (< net40) (< netstandard1.1) (>= netstandard1.5) (< win8)) (&& (< monoandroid) (< net40) (< netstandard1.1) (>= netstandard1.6) (< win8)) (&& (< monoandroid) (< net40) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< monoandroid) (< net40) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< monoandroid) (< net40) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= net46) (< netstandard1.4)) (&& (< net40) (>= netstandard1.3) (< portable-net45+win8+wpa81)) (&& (>= netcoreapp5.0) (< netstandard1.2)) (&& (>= netcoreapp5.0) (< netstandard1.4)) (&& (>= netcoreapp5.0) (< netstandard1.5)) (&& (>= netcoreapp5.0) (< netstandard1.6)) (&& (>= netcoreapp5.0) (< netstandard2.0)) (&& (>= netcoreapp5.0) (< portable-net45+win8+wpa81)) (&& (< netstandard1.1) (>= uap10.0) (< win8)) (&& (< netstandard1.3) (>= uap10.0) (< win8) (< wpa81)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1)) (&& (< netstandard1.5) (>= uap10.0) (< win8) (< wpa81))
     Microsoft.NETFramework.ReferenceAssemblies (1.0) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.NETFramework.ReferenceAssemblies.net461 (>= 1.0) - restriction: && (>= net461) (< net462)
@@ -57,10 +81,16 @@ NUGET
     Microsoft.NETFramework.ReferenceAssemblies.net471 (1.0) - restriction: && (>= net471) (< net472)
     Microsoft.NETFramework.ReferenceAssemblies.net472 (1.0) - restriction: && (>= net472) (< net48)
     Microsoft.NETFramework.ReferenceAssemblies.net48 (1.0) - restriction: >= net48
+    Microsoft.VisualStudio.Setup.Configuration.Interop (1.16.30) - restriction: >= net472
     Microsoft.Win32.Primitives (4.3) - restriction: || (&& (< monoandroid) (< net40) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< net40) (>= net46) (< netstandard1.4)) (&& (< net40) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1)) (&& (< netstandard1.5) (>= uap10.0) (< win8) (< wpa81))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+    Microsoft.Win32.Registry (4.7) - restriction: && (< net472) (>= netstandard2.0)
+      System.Buffers (>= 4.5) - restriction: || (>= monoandroid) (>= monotouch) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+      System.Memory (>= 4.5.3) - restriction: || (&& (< monoandroid) (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (>= uap10.1)
+      System.Security.AccessControl (>= 4.7) - restriction: || (>= monoandroid) (>= monotouch) (&& (< net46) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+      System.Security.Principal.Windows (>= 4.7) - restriction: || (>= monoandroid) (>= monotouch) (&& (< net46) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
     Microsoft.Win32.SystemEvents (4.7) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 3.1) - restriction: >= netcoreapp2.0
     NETStandard.Library (2.0.3) - restriction: && (< net40) (>= netstandard1.3) (< netstandard2.0)
@@ -156,6 +186,7 @@ NUGET
     System.AppContext (4.3) - restriction: || (&& (< net40) (>= net46) (< netstandard1.4)) (&& (< net40) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1))
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.6)) (>= netcoreapp5.0)
     System.Buffers (4.5.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< monoandroid) (< net40) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= net46) (< netstandard1.4)) (>= net461) (&& (>= netcoreapp5.0) (< netstandard1.2)) (&& (>= netcoreapp5.0) (< netstandard1.4)) (&& (>= netcoreapp5.0) (< netstandard1.5)) (&& (>= netcoreapp5.0) (< netstandard1.6)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1)) (&& (< netstandard1.5) (>= uap10.0) (< win8) (< wpa81)) (>= netstandard2.0)
+    System.CodeDom (4.7) - restriction: && (< net472) (>= netstandard2.0)
     System.Collections (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< netstandard2.0) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< monoandroid) (< net40) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= net46) (< netstandard1.4)) (&& (< net40) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< net40) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.3) (< netstandard2.0)) (&& (< net40) (>= netstandard1.3) (< portable-net45+win8+wpa81)) (&& (< net40) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.6) (< portable-net45+win8+wpa81)) (&& (>= netcoreapp5.0) (< netstandard1.2)) (&& (>= netcoreapp5.0) (< netstandard1.4)) (&& (>= netcoreapp5.0) (< netstandard1.5)) (&& (>= netcoreapp5.0) (< netstandard1.6)) (&& (>= netcoreapp5.0) (< netstandard2.0)) (&& (>= netcoreapp5.0) (< portable-net45+win8+wpa81)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (>= netcoreapp5.0)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (>= netcoreapp5.0)
@@ -376,7 +407,7 @@ NUGET
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netcoreapp5.0)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netcoreapp5.0)
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netcoreapp5.0)
-    System.Reflection.TypeExtensions (4.7) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< monoandroid) (< net40) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.6) (< portable-net45+win8+wpa81)) (&& (< net461) (>= netstandard2.0)) (&& (>= netcoreapp5.0) (< netstandard1.2)) (&& (>= netcoreapp5.0) (< netstandard1.4)) (&& (>= netcoreapp5.0) (< netstandard1.5)) (&& (>= netcoreapp5.0) (< netstandard1.6)) (&& (>= netcoreapp5.0) (< netstandard2.0)) (&& (>= netcoreapp5.0) (< portable-net45+win8+wpa81)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0))
+    System.Reflection.TypeExtensions (4.7) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< monoandroid) (< net40) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.6) (< portable-net45+win8+wpa81)) (&& (< net461) (>= netstandard2.0)) (&& (< net472) (>= netstandard2.0)) (&& (>= netcoreapp5.0) (< netstandard1.2)) (&& (>= netcoreapp5.0) (< netstandard1.4)) (&& (>= netcoreapp5.0) (< netstandard1.5)) (&& (>= netcoreapp5.0) (< netstandard1.6)) (&& (>= netcoreapp5.0) (< netstandard2.0)) (&& (>= netcoreapp5.0) (< portable-net45+win8+wpa81)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0))
       System.Diagnostics.Contracts (>= 4.3) - restriction: >= netcoreapp5.0
       System.Diagnostics.Debug (>= 4.3) - restriction: >= netcoreapp5.0
       System.Linq (>= 4.3) - restriction: >= netcoreapp5.0
@@ -385,6 +416,8 @@ NUGET
       System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.5) (< netstandard2.0) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.5) (< uap10.1)) (>= netcoreapp5.0)
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.5) (< netstandard2.0) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.5) (< uap10.1)) (>= netcoreapp5.0)
       System.Runtime.Extensions (>= 4.3) - restriction: >= netcoreapp5.0
+    System.Resources.Extensions (4.7.1) - restriction: >= netstandard2.0
+      System.Memory (>= 4.5.4) - restriction: || (&& (< monoandroid) (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= net461)
     System.Resources.ResourceManager (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< netstandard2.0) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< monoandroid) (< net40) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= net46) (< netstandard1.4)) (&& (< net40) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< net40) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.3) (< portable-net45+win8+wpa81)) (&& (< net40) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.6) (< portable-net45+win8+wpa81)) (>= netcoreapp5.0) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1)) (&& (< netstandard1.5) (>= uap10.0) (< win8) (< wpa81))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netcoreapp5.0)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netcoreapp5.0)
@@ -394,7 +427,7 @@ NUGET
     System.Runtime (4.3.1) - restriction: || (&& (< monoandroid) (< net40) (< netstandard1.1) (>= netstandard1.3) (< win8)) (&& (< monoandroid) (< net40) (< netstandard1.1) (>= netstandard1.4) (< win8)) (&& (< monoandroid) (< net40) (< netstandard1.1) (>= netstandard1.5) (< win8)) (&& (< monoandroid) (< net40) (< netstandard1.1) (>= netstandard1.6) (< win8)) (&& (< monoandroid) (< net40) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net461) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (< net40) (>= net46) (< netstandard1.4)) (&& (< net40) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< net40) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.3) (< portable-net45+win8+wpa81)) (&& (< net40) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.6) (< portable-net45+win8+wpa81)) (>= netcoreapp5.0) (&& (< netstandard1.1) (>= uap10.0) (< win8)) (&& (< netstandard1.3) (>= uap10.0) (< win8) (< wpa81)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1)) (&& (< netstandard1.5) (>= uap10.0) (< win8) (< wpa81))
       Microsoft.NETCore.Platforms (>= 1.1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp5.0)
       Microsoft.NETCore.Targets (>= 1.1.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp5.0)
-    System.Runtime.CompilerServices.Unsafe (4.7.1) - restriction: || (&& (>= monoandroid) (>= netcoreapp2.0)) (&& (>= monoandroid) (>= netstandard2.0)) (&& (>= monotouch) (>= netcoreapp2.0)) (&& (>= monotouch) (>= netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (>= netcoreapp2.0) (< netstandard1.0)) (&& (>= netcoreapp2.0) (< netstandard2.0)) (&& (>= netcoreapp2.0) (>= uap10.1)) (&& (>= netcoreapp2.0) (>= wp8)) (&& (>= netcoreapp2.0) (>= xamarintvos)) (&& (>= netcoreapp2.0) (>= xamarinwatchos)) (&& (>= netcoreapp2.1) (< netcoreapp3.0)) (&& (< netstandard1.1) (>= netstandard2.0) (>= win8)) (&& (< netstandard1.1) (>= netstandard2.0) (< win8)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= xamarintvos)) (&& (>= netstandard2.0) (>= xamarinwatchos)) (>= xamarinios) (>= xamarinmac)
+    System.Runtime.CompilerServices.Unsafe (4.7.1) - restriction: || (&& (>= monoandroid) (>= netcoreapp2.0)) (&& (>= monoandroid) (>= netstandard2.0)) (&& (< monoandroid) (< net46) (< netcoreapp2.0) (>= netstandard2.0)) (&& (>= monotouch) (>= netcoreapp2.0)) (&& (>= monotouch) (>= netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (>= netcoreapp2.0) (< netcoreapp3.1)) (&& (>= netcoreapp2.0) (< netstandard1.0)) (&& (>= netcoreapp2.0) (< netstandard2.0)) (&& (>= netcoreapp2.0) (>= uap10.1)) (&& (>= netcoreapp2.0) (>= wp8)) (&& (>= netcoreapp2.0) (>= xamarintvos)) (&& (>= netcoreapp2.0) (>= xamarinwatchos)) (&& (>= netcoreapp2.1) (< netcoreapp3.0)) (&& (< netstandard1.1) (>= netstandard2.0) (>= win8)) (&& (< netstandard1.1) (>= netstandard2.0) (< win8)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= xamarintvos)) (&& (>= netstandard2.0) (>= xamarinwatchos)) (>= xamarinios) (>= xamarinmac)
     System.Runtime.Extensions (4.3.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< netstandard2.0) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< monoandroid) (< net40) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= net46) (< netstandard1.4)) (&& (< net40) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< net40) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.3) (< portable-net45+win8+wpa81)) (&& (< net40) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.6) (< portable-net45+win8+wpa81)) (>= netcoreapp5.0) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1)) (&& (< netstandard1.5) (>= uap10.0) (< win8) (< wpa81))
       Microsoft.NETCore.Platforms (>= 1.1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp5.0)
       Microsoft.NETCore.Targets (>= 1.1.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp5.0)
@@ -427,7 +460,7 @@ NUGET
       System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netcoreapp5.0)
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (>= netcoreapp5.0)
       System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netcoreapp5.0)
-    System.Security.AccessControl (4.7) - restriction: >= netstandard2.0
+    System.Security.AccessControl (4.7) - restriction: && (< net472) (>= netstandard2.0)
       Microsoft.NETCore.Platforms (>= 3.1) - restriction: >= netcoreapp2.0
       System.Security.Principal.Windows (>= 4.7) - restriction: || (&& (>= net46) (< netstandard2.0)) (&& (< net46) (>= netstandard1.3) (< netstandard2.0) (< uap10.1)) (&& (< net46) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0)
     System.Security.Cryptography.Algorithms (4.3.1) - restriction: || (&& (< monoandroid) (< net40) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< monoandroid) (< net40) (< netstandard1.4) (>= netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= net46) (< netstandard1.4)) (&& (< net40) (>= net461) (< netstandard1.4)) (&& (< net40) (>= net461) (>= netstandard1.5) (< netstandard1.6)) (&& (< net40) (>= net461) (< netstandard1.5)) (&& (< net40) (>= net461) (>= netstandard1.6) (< netstandard2.0)) (&& (< net40) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (>= net461) (< netstandard1.5) (>= uap10.0)) (&& (>= netcoreapp5.0) (< netstandard1.4)) (&& (>= netcoreapp5.0) (< netstandard1.5)) (&& (>= netcoreapp5.0) (< netstandard1.6)) (&& (>= netcoreapp5.0) (< netstandard2.0)) (&& (< netstandard1.4) (>= uap10.0)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1))
@@ -535,12 +568,15 @@ NUGET
     System.Security.Permissions (4.7) - restriction: >= netstandard2.0
       System.Security.AccessControl (>= 4.7) - restriction: || (>= net461) (>= netstandard2.0)
       System.Windows.Extensions (>= 4.7) - restriction: >= netcoreapp3.0
-    System.Security.Principal.Windows (4.7) - restriction: || (&& (< net46) (>= netstandard2.0)) (&& (>= net461) (>= netstandard2.0)) (>= netcoreapp2.0)
+    System.Security.Principal.Windows (4.7) - restriction: || (&& (>= monoandroid) (>= netstandard2.0)) (&& (>= monotouch) (>= netstandard2.0)) (&& (< net46) (>= netstandard2.0)) (&& (>= net461) (< net472) (>= netstandard2.0)) (>= netcoreapp2.0) (&& (>= netstandard2.0) (>= xamarintvos)) (&& (>= netstandard2.0) (>= xamarinwatchos)) (>= xamarinios) (>= xamarinmac)
       Microsoft.NETCore.Platforms (>= 3.1) - restriction: || (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (>= netcoreapp2.1) (< netcoreapp3.0))
     System.Text.Encoding (4.3) - restriction: || (&& (< monoandroid) (< net40) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= net46) (< netstandard1.3)) (&& (< net40) (>= net46) (< netstandard1.4)) (&& (< net40) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< net40) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.3) (< portable-net45+win8+wpa81)) (&& (< net40) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (>= netcoreapp5.0) (< netstandard1.2)) (&& (>= netcoreapp5.0) (< netstandard1.4)) (&& (>= netcoreapp5.0) (< netstandard1.5)) (&& (>= netcoreapp5.0) (< netstandard1.6)) (&& (>= netcoreapp5.0) (< netstandard2.0)) (&& (< netstandard1.3) (>= uap10.0) (< win8) (< wpa81)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1)) (&& (< netstandard1.5) (>= uap10.0) (< win8) (< wpa81))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (>= netcoreapp5.0)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (>= netcoreapp5.0)
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (>= netcoreapp5.0)
+    System.Text.Encoding.CodePages (4.7.1) - restriction: && (< net472) (>= netstandard2.0)
+      Microsoft.NETCore.Platforms (>= 3.1.1) - restriction: >= netcoreapp2.0
+      System.Runtime.CompilerServices.Unsafe (>= 4.7.1) - restriction: || (&& (< monoandroid) (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp3.1))
     System.Text.Encoding.Extensions (4.3) - restriction: || (&& (< net40) (>= net46) (< netstandard1.4)) (&& (< net40) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< net40) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.3) (< portable-net45+win8+wpa81)) (&& (< net40) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (>= netcoreapp5.0) (< netstandard1.2)) (&& (>= netcoreapp5.0) (< netstandard1.4)) (&& (>= netcoreapp5.0) (< netstandard1.5)) (&& (>= netcoreapp5.0) (< netstandard1.6)) (&& (>= netcoreapp5.0) (< netstandard2.0)) (&& (>= netcoreapp5.0) (< portable-net45+win8+wpa81)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1)) (&& (< netstandard1.5) (>= uap10.0) (< win8) (< wpa81))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (>= netcoreapp5.0)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (>= netcoreapp5.0)
@@ -568,6 +604,7 @@ NUGET
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (>= netcoreapp5.0)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (>= netcoreapp5.0)
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (>= netcoreapp5.0)
+    System.Threading.Tasks.Dataflow (4.11.1) - restriction: >= netstandard2.0
     System.Threading.Tasks.Extensions (4.5.4) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< monoandroid) (< net40) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= net46) (< netstandard1.4)) (&& (< net40) (>= netstandard1.3) (< portable-net45+win8+wpa81)) (&& (>= net461) (>= netcoreapp2.0)) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (>= netcoreapp2.0) (>= uap10.1)) (&& (>= netcoreapp5.0) (< netstandard1.2)) (&& (>= netcoreapp5.0) (< netstandard1.4)) (&& (>= netcoreapp5.0) (< netstandard1.5)) (&& (>= netcoreapp5.0) (< netstandard1.6)) (&& (>= netcoreapp5.0) (< netstandard2.0)) (&& (>= netcoreapp5.0) (< portable-net45+win8+wpa81)) (&& (< netstandard1.5) (>= uap10.0) (< win8) (< wpa81))
       System.Runtime.CompilerServices.Unsafe (>= 4.5.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< win8)) (&& (>= net45) (< netstandard2.0)) (>= net461) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= wp8)
     System.Threading.Timer (4.3) - restriction: || (&& (< net40) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1))
@@ -608,23 +645,23 @@ NUGET
       System.Xml.ReaderWriter (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (>= netcoreapp5.0)
   remote: paket-files/github.com/fsharp/FsAutoComplete/bin/pkgs
     ProjectSystem (0.41.1)
-      Dotnet.ProjInfo (>= 0.41.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Dotnet.ProjInfo.Workspace.FCS (>= 0.41.1) - restriction: || (>= net461) (>= netstandard2.0)
-      FSharp.Compiler.Service (>= 35.0) - restriction: || (>= net461) (>= netstandard2.0)
+      Dotnet.ProjInfo (>= 0.44) - restriction: || (>= net461) (>= netstandard2.0)
+      Dotnet.ProjInfo.Workspace.FCS (>= 0.44) - restriction: || (>= net461) (>= netstandard2.0)
+      FSharp.Compiler.Service (>= 37.0) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.NETFramework.ReferenceAssemblies (>= 1.0) - restriction: || (>= net461) (>= netstandard2.0)
       Newtonsoft.Json (>= 12.0.3) - restriction: || (>= net461) (>= netstandard2.0)
       Sln (>= 0.3) - restriction: || (>= net461) (>= netstandard2.0)
 GIT
   remote: https://github.com/fsharp/FsAutoComplete.git
-     (f958a902d30cfc283b515868f5b592fbee59542c)
+     (2346b3e2f3dcfbfdb14381484879514d6f43f1f0)
       build: build.cmd
       path: /bin/pkgs/
       os: win
-     (f958a902d30cfc283b515868f5b592fbee59542c)
+     (2346b3e2f3dcfbfdb14381484879514d6f43f1f0)
       build: build.sh
       path: /bin/pkgs/
       os: osx
-     (f958a902d30cfc283b515868f5b592fbee59542c)
+     (2346b3e2f3dcfbfdb14381484879514d6f43f1f0)
       build: build.sh
       path: /bin/pkgs/
       os: linux
@@ -636,116 +673,116 @@ NUGET
       FSharp.Core (>= 4.0.0.1) - restriction: >= net45
       FSharp.Core (>= 4.2.3) - restriction: && (< net45) (>= netstandard2.0)
       Microsoft.Win32.Registry (>= 4.7) - restriction: && (< net45) (>= netstandard2.0)
-    Fake.Api.GitHub (5.20.2)
+    Fake.Api.GitHub (5.20.3)
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
       Octokit (>= 0.48) - restriction: >= netstandard2.0
-    Fake.Core.CommandLineParsing (5.20.2) - restriction: >= netstandard2.0
+    Fake.Core.CommandLineParsing (5.20.3) - restriction: >= netstandard2.0
       FParsec (>= 1.1.1) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.Context (5.20.2) - restriction: >= netstandard2.0
+    Fake.Core.Context (5.20.3) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.Environment (5.20.2)
+    Fake.Core.Environment (5.20.3)
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.FakeVar (5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.Context (>= 5.20.2) - restriction: >= netstandard2.0
+    Fake.Core.FakeVar (5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.Context (>= 5.20.3) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.Process (5.20.2)
-      Fake.Core.Environment (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.FakeVar (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.IO.FileSystem (>= 5.20.2) - restriction: >= netstandard2.0
+    Fake.Core.Process (5.20.3)
+      Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.FakeVar (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.IO.FileSystem (>= 5.20.3) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
       System.Collections.Immutable (>= 1.7.1) - restriction: >= netstandard2.0
-    Fake.Core.ReleaseNotes (5.20.2)
-      Fake.Core.SemVer (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.2) - restriction: >= netstandard2.0
+    Fake.Core.ReleaseNotes (5.20.3)
+      Fake.Core.SemVer (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.SemVer (5.20.2) - restriction: >= netstandard2.0
+    Fake.Core.SemVer (5.20.3) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.String (5.20.2) - restriction: >= netstandard2.0
+    Fake.Core.String (5.20.3) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.Target (5.20.2)
-      Fake.Core.CommandLineParsing (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.Context (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.Environment (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.FakeVar (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.Process (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.2) - restriction: >= netstandard2.0
-      FSharp.Control.Reactive (>= 4.4) - restriction: >= netstandard2.0
+    Fake.Core.Target (5.20.3)
+      Fake.Core.CommandLineParsing (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.Context (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.FakeVar (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.Process (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
+      FSharp.Control.Reactive (>= 4.4.2) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.Tasks (5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.2) - restriction: >= netstandard2.0
+    Fake.Core.Tasks (5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.Trace (5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.Environment (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.FakeVar (>= 5.20.2) - restriction: >= netstandard2.0
+    Fake.Core.Trace (5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.FakeVar (>= 5.20.3) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.UserInput (5.20.2)
+    Fake.Core.UserInput (5.20.3)
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Core.Xml (5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.2) - restriction: >= netstandard2.0
+    Fake.Core.Xml (5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.DotNet.AssemblyInfoFile (5.20.2)
-      Fake.Core.Environment (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.IO.FileSystem (>= 5.20.2) - restriction: >= netstandard2.0
+    Fake.DotNet.AssemblyInfoFile (5.20.3)
+      Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.IO.FileSystem (>= 5.20.3) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.DotNet.Cli (5.20.2)
-      Fake.Core.Environment (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.Process (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.DotNet.MSBuild (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.DotNet.NuGet (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.IO.FileSystem (>= 5.20.2) - restriction: >= netstandard2.0
+    Fake.DotNet.Cli (5.20.3)
+      Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.Process (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.DotNet.MSBuild (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.DotNet.NuGet (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.IO.FileSystem (>= 5.20.3) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
       Mono.Posix.NETStandard (>= 1.0) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 12.0.3) - restriction: >= netstandard2.0
-    Fake.DotNet.MSBuild (5.20.2)
+    Fake.DotNet.MSBuild (5.20.3)
       BlackFox.VsWhere (>= 1.1) - restriction: >= netstandard2.0
-      Fake.Core.Environment (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.Process (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.IO.FileSystem (>= 5.20.2) - restriction: >= netstandard2.0
+      Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.Process (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.IO.FileSystem (>= 5.20.3) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-      MSBuild.StructuredLogger (>= 2.1.133) - restriction: >= netstandard2.0
-    Fake.DotNet.NuGet (5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.Environment (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.Process (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.SemVer (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.Tasks (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.Xml (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.IO.FileSystem (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Net.Http (>= 5.20.2) - restriction: >= netstandard2.0
+      MSBuild.StructuredLogger (>= 2.1.176) - restriction: >= netstandard2.0
+    Fake.DotNet.NuGet (5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.Process (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.SemVer (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.Tasks (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.Xml (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.IO.FileSystem (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Net.Http (>= 5.20.3) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 12.0.3) - restriction: >= netstandard2.0
       NuGet.Protocol (>= 5.6) - restriction: >= netstandard2.0
-    Fake.DotNet.Paket (5.20.2)
-      Fake.Core.Process (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.DotNet.Cli (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.IO.FileSystem (>= 5.20.2) - restriction: >= netstandard2.0
+    Fake.DotNet.Paket (5.20.3)
+      Fake.Core.Process (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.DotNet.Cli (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.IO.FileSystem (>= 5.20.3) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.IO.FileSystem (5.20.2)
-      Fake.Core.String (>= 5.20.2) - restriction: >= netstandard2.0
+    Fake.IO.FileSystem (5.20.3)
+      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Net.Http (5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.2) - restriction: >= netstandard2.0
+    Fake.Net.Http (5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fake.Tools.Git (5.20.2)
-      Fake.Core.Environment (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.Process (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.SemVer (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.String (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.Core.Trace (>= 5.20.2) - restriction: >= netstandard2.0
-      Fake.IO.FileSystem (>= 5.20.2) - restriction: >= netstandard2.0
+    Fake.Tools.Git (5.20.3)
+      Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.Process (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.SemVer (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
+      Fake.IO.FileSystem (>= 5.20.3) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
     FParsec (1.1.1) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.3.4) - restriction: || (>= net45) (>= netstandard2.0)
@@ -778,6 +815,7 @@ NUGET
       System.Resources.Extensions (>= 4.6) - restriction: >= netstandard2.0
       System.Security.Permissions (>= 4.7) - restriction: && (< net472) (>= netstandard2.0)
       System.Threading.Tasks.Dataflow (>= 4.9) - restriction: >= netstandard2.0
+    Microsoft.Build.Tasks.Git (1.0) - restriction: >= netstandard2.0
     Microsoft.Build.Utilities.Core (16.6) - restriction: >= netstandard2.0
       Microsoft.Build.Framework (>= 16.6) - restriction: >= netstandard2.0
       Microsoft.VisualStudio.Setup.Configuration.Interop (>= 1.16.30) - restriction: >= net472
@@ -785,8 +823,12 @@ NUGET
       System.Collections.Immutable (>= 1.5) - restriction: >= netstandard2.0
       System.Security.Permissions (>= 4.7) - restriction: && (< net472) (>= netstandard2.0)
       System.Text.Encoding.CodePages (>= 4.0.1) - restriction: && (< net472) (>= netstandard2.0)
-    Microsoft.NETCore.Platforms (3.1.1) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< net46) (< netcoreapp5.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= netcoreapp2.0)
-    Microsoft.NETCore.Targets (3.1) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< net46) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= netcoreapp5.0)
+    Microsoft.NETCore.Platforms (3.1.2) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< net46) (< netcoreapp5.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= netcoreapp2.0)
+    Microsoft.NETCore.Targets (3.1) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< net46) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= netcoreapp5.0)
+    Microsoft.SourceLink.Common (1.0) - restriction: >= netstandard2.0
+    Microsoft.SourceLink.GitHub (1.0) - restriction: >= netstandard2.0
+      Microsoft.Build.Tasks.Git (>= 1.0)
+      Microsoft.SourceLink.Common (>= 1.0)
     Microsoft.VisualStudio.Setup.Configuration.Interop (1.16.30) - restriction: >= net472
     Microsoft.Win32.Primitives (4.3) - restriction: && (< monoandroid) (< net46) (< netcoreapp5.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -800,12 +842,12 @@ NUGET
     Microsoft.Win32.SystemEvents (4.7) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 3.1) - restriction: >= netcoreapp2.0
     Mono.Posix.NETStandard (1.0) - restriction: >= netstandard2.0
-    MSBuild.StructuredLogger (2.1.133) - restriction: >= netstandard2.0
+    MSBuild.StructuredLogger (2.1.176) - restriction: >= netstandard2.0
       Microsoft.Build (>= 16.4) - restriction: >= netstandard2.0
       Microsoft.Build.Framework (>= 16.4) - restriction: >= netstandard2.0
       Microsoft.Build.Tasks.Core (>= 16.4) - restriction: >= netstandard2.0
       Microsoft.Build.Utilities.Core (>= 16.4) - restriction: >= netstandard2.0
-      System.IO.Compression (>= 4.3) - restriction: >= netstandard2.0
+      Microsoft.SourceLink.GitHub (>= 1.0) - restriction: >= netstandard2.0
     Newtonsoft.Json (12.0.3) - restriction: >= netstandard2.0
     NuGet.Common (5.6) - restriction: >= netstandard2.0
       NuGet.Frameworks (>= 5.6) - restriction: >= netstandard2.0
@@ -825,13 +867,10 @@ NUGET
       System.Dynamic.Runtime (>= 4.3) - restriction: && (< net472) (>= netstandard2.0)
     NuGet.Versioning (5.6) - restriction: >= netstandard2.0
     Octokit (0.48) - restriction: >= netstandard2.0
-    runtime.native.System (4.3.1) - restriction: || (&& (< monoandroid) (< net45) (< netcoreapp5.0) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< net46) (< netcoreapp5.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac))
+    runtime.native.System (4.3.1) - restriction: && (< monoandroid) (< net46) (< netcoreapp5.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.IO.Compression (4.3.2) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (>= netcoreapp5.0)
-      Microsoft.NETCore.Platforms (>= 1.1.1)
-      Microsoft.NETCore.Targets (>= 1.1.3)
-    System.Buffers (4.5.1) - restriction: || (&& (>= monoandroid) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard2.0) (< win8)) (&& (>= monotouch) (>= netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (&& (>= net461) (>= netstandard2.0)) (>= netcoreapp5.0) (&& (< netstandard1.1) (>= netstandard2.0) (>= win8)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= xamarintvos)) (&& (>= netstandard2.0) (>= xamarinwatchos)) (>= xamarinios) (>= xamarinmac)
+    System.Buffers (4.5.1) - restriction: || (&& (>= monoandroid) (>= netstandard2.0)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard2.0) (< win8)) (&& (>= monotouch) (>= netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (&& (>= net461) (>= netstandard2.0)) (&& (< netstandard1.1) (>= netstandard2.0) (>= win8)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= xamarintvos)) (&& (>= netstandard2.0) (>= xamarinwatchos)) (>= xamarinios) (>= xamarinmac)
     System.CodeDom (4.7) - restriction: && (< net472) (>= netstandard2.0)
     System.Collections (4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< net46) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= netcoreapp5.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (>= netcoreapp5.0)
@@ -887,7 +926,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (>= netcoreapp5.0)
       System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netcoreapp5.0)
       System.Threading (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netcoreapp5.0)
-    System.Globalization (4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< net46) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= netcoreapp5.0)
+    System.Globalization (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< net46) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= netcoreapp5.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (>= netcoreapp5.0)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (>= netcoreapp5.0)
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (>= netcoreapp5.0)
@@ -897,22 +936,6 @@ NUGET
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp5.0)
       System.Text.Encoding (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp5.0)
       System.Threading.Tasks (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp5.0)
-    System.IO.Compression (4.3) - restriction: >= netstandard2.0
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net45) (< netcoreapp5.0) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (< netcoreapp5.0) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      runtime.native.System.IO.Compression (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netcoreapp5.0)
-      System.Buffers (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netcoreapp5.0)
-      System.Collections (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netcoreapp5.0)
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netcoreapp5.0)
-      System.IO (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (>= netcoreapp5.0)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netcoreapp5.0)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (>= netcoreapp5.0)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netcoreapp5.0)
-      System.Runtime.Handles (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netcoreapp5.0)
-      System.Runtime.InteropServices (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netcoreapp5.0)
-      System.Text.Encoding (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (>= netcoreapp5.0)
-      System.Threading (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netcoreapp5.0)
-      System.Threading.Tasks (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netcoreapp5.0)
     System.IO.FileSystem (4.3) - restriction: && (< monoandroid) (< net46) (< netcoreapp5.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -968,7 +991,7 @@ NUGET
       System.Runtime.InteropServices.WindowsRuntime (>= 4.3) - restriction: && (< net46) (< netcoreapp3.0) (>= netstandard2.0) (< uap10.0)
       System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (>= net46) (&& (< netcoreapp3.0) (>= netstandard2.0)) (>= uap10.0)
       System.ValueTuple (>= 4.5) - restriction: || (>= net46) (&& (>= uap10.0) (< uap10.1))
-    System.Reflection (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< net46) (< netstandard1.5) (>= netstandard2.0)) (>= netcoreapp5.0)
+    System.Reflection (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< net46) (< netstandard1.5) (>= netstandard2.0)) (&& (>= netcoreapp1.1) (>= netstandard2.0)) (>= netcoreapp5.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp5.0)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp5.0)
       System.IO (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp5.0)
@@ -990,7 +1013,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netcoreapp5.0)
     System.Reflection.Metadata (1.8.1) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= netcoreapp2.1)
       System.Collections.Immutable (>= 1.7.1) - restriction: || (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp3.1) (>= netstandard2.0)) (&& (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (>= net461) (&& (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (>= wpa81))
-    System.Reflection.Primitives (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (>= netcoreapp1.1) (>= netstandard2.0)) (>= netcoreapp5.0)
+    System.Reflection.Primitives (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (>= netcoreapp5.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netcoreapp5.0)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netcoreapp5.0)
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netcoreapp5.0)
@@ -1019,11 +1042,11 @@ NUGET
       Microsoft.NETCore.Platforms (>= 1.1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp5.0)
       Microsoft.NETCore.Targets (>= 1.1.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp5.0)
       System.Runtime (>= 4.3.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp5.0)
-    System.Runtime.Handles (4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< net46) (< netstandard1.4) (>= netstandard2.0)) (&& (< monoandroid) (< net46) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= netcoreapp5.0)
+    System.Runtime.Handles (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netcoreapp5.0) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net46) (< netcoreapp5.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< net46) (< netstandard1.4) (>= netstandard2.0)) (&& (>= netcoreapp1.1) (< netcoreapp5.0) (>= netstandard2.0))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Runtime.InteropServices (4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< net46) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= netcoreapp5.0)
+    System.Runtime.InteropServices (4.3) - restriction: && (< monoandroid) (< net46) (< netcoreapp5.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp1.1)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp1.1)
       System.Reflection (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp1.1)
@@ -1042,7 +1065,7 @@ NUGET
       System.Windows.Extensions (>= 4.7) - restriction: >= netcoreapp3.0
     System.Security.Principal.Windows (4.7) - restriction: || (&& (>= monoandroid) (>= netstandard2.0)) (&& (>= monotouch) (>= netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (>= netcoreapp2.0) (&& (>= netstandard2.0) (>= xamarintvos)) (&& (>= netstandard2.0) (>= xamarinwatchos)) (>= xamarinios) (>= xamarinmac)
       Microsoft.NETCore.Platforms (>= 3.1) - restriction: || (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (>= netcoreapp2.1) (< netcoreapp3.0))
-    System.Text.Encoding (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< net46) (< netstandard1.4) (>= netstandard2.0)) (&& (< monoandroid) (< net46) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= netcoreapp5.0)
+    System.Text.Encoding (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< net46) (< netstandard1.4) (>= netstandard2.0)) (&& (< monoandroid) (< net46) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= netcoreapp5.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (>= netcoreapp5.0)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (>= netcoreapp5.0)
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (>= netcoreapp5.0)
@@ -1057,7 +1080,7 @@ NUGET
     System.Threading (4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< net46) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= netcoreapp5.0)
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (>= netcoreapp5.0)
       System.Threading.Tasks (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (>= netcoreapp5.0)
-    System.Threading.Tasks (4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< net46) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= netcoreapp5.0)
+    System.Threading.Tasks (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< net46) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= netcoreapp5.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (>= netcoreapp5.0)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (>= netcoreapp5.0)
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (>= netcoreapp5.0)


### PR DESCRIPTION
This is WIP so far, but here's the updated FCS version of the analyzer SDK.

The tests are failing at startup due to project cracking having a missingmethodexception, which is  hard to unwrap. Currently, if you `dotnet fake build -t RunSample`, you get the following exception:

```
Unhandled exception. System.MissingMethodException: Method not found: 'Void Dotnet.ProjInfo.Workspace.Loader.LoadProjects(Microsoft.FSharp.Collections.FSharpList`1<System.String>, Microsoft.FSharp.Core.FSharpFunc`2<System.String,Microsoft.FSharp.Core.FSharpFunc`2<System.Tuple`3<System.String,System.String,Microsoft.FSharp.Collections.FSharpList`1<System.String>>,System.String>>)'.
   at ProjectSystem.Workspace.getProjectOptions(Loader loader, FCSBinder fcsBinder, String projectFileName)
   at <StartupCode$ProjectSystem>.$ProjectSystem.LoadProject@109.Invoke(Unit unitVar)
   at Microsoft.FSharp.Control.AsyncPrimitives.CallThenInvoke[T,TResult](AsyncActivation`1 ctxt, TResult result1, FSharpFunc`2 part2) in F:\workspace\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 398
   at Program.loadProject@58-5.Invoke(AsyncActivation`1 ctxt) in /Users/chethusk/oss/FSharp.Analyzers.SDK/src/FSharp.Analyzers.Cli/Program.fs:line 58
   at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction) in F:\workspace\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 109
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.FSharp.Control.AsyncResult`1.Commit() in F:\workspace\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 350
   at Microsoft.FSharp.Control.AsyncPrimitives.RunSynchronouslyInCurrentThread[a](CancellationToken cancellationToken, FSharpAsync`1 computation) in F:\workspace\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 882
   at Microsoft.FSharp.Control.AsyncPrimitives.RunSynchronously[T](CancellationToken cancellationToken, FSharpAsync`1 computation, FSharpOption`1 timeout) in F:\workspace\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 890
   at Microsoft.FSharp.Control.FSharpAsync.RunSynchronously[T](FSharpAsync`1 computation, FSharpOption`1 timeout, FSharpOption`1 cancellationToken) in F:\workspace\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 1154
   at Program.loadProject(String file) in /Users/chethusk/oss/FSharp.Analyzers.SDK/src/FSharp.Analyzers.Cli/Program.fs:line 57
   at Program.runProject(String proj, FSharpList`1 globs) in /Users/chethusk/oss/FSharp.Analyzers.SDK/src/FSharp.Analyzers.Cli/Program.fs:line 136
   at Program.main(String[] argv) in /Users/chethusk/oss/FSharp.Analyzers.SDK/src/FSharp.Analyzers.Cli/Program.fs:line 223
```

however, the versions of ProjectSystem and DPI that we bring down appear to be using different overloads than the one erroring here.