### PR TITLE
Verify sdk version

### DIFF
--- a/src/FSharp.Analyzers.Cli/Program.fs
+++ b/src/FSharp.Analyzers.Cli/Program.fs
@@ -27,7 +27,7 @@ let createFCS () =
     checker
 let fcs = createFCS ()
 
-let parser = ArgumentParser.Create<Arguments>()
+let parser = ArgumentParser.Create<Arguments>(errorHandler = ProcessExiter ())
 
 let rec mkKn (ty: System.Type) =
     if Reflection.FSharpType.IsFunction(ty) then

--- a/src/FSharp.Analyzers.Cli/Program.fs
+++ b/src/FSharp.Analyzers.Cli/Program.fs
@@ -195,7 +195,7 @@ let main argv =
 
     printInfo "Loading analyzers from %s" analyzersPath
 
-    let (dlls, analyzers) = Client.loadAnalyzers analyzersPath
+    let dlls, analyzers = Client.loadAnalyzers (printError "%s") analyzersPath
     printInfo "Registered %d analyzers from %d dlls" analyzers dlls
 
     let projOpt = results.TryGetResult <@ Project @>


### PR DESCRIPTION
It can be very confusing when your analyzer is targeting the wrong SDK and gets loaded anyway by the cli tool. I propose to enforce using the correct version instead.