### PR TITLE
Add symbol uses to Context

### DIFF
--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fs
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fs
@@ -2,6 +2,7 @@ namespace FSharp.Analyzers.SDK
 
 open System
 open FSharp.Compiler
+open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Symbols
 open FSharp.Compiler.EditorServices
@@ -20,7 +21,9 @@ type Context =
       ParseTree: ParsedInput
       TypedTree: FSharpImplementationFileContents
       Symbols: FSharpEntity list
-      GetAllEntities: bool -> AssemblySymbol list }
+      GetAllEntities: bool -> AssemblySymbol list
+      AllSymbolUses: FSharpSymbolUse array
+      SymbolUsesOfFile: FSharpSymbolUse array }
 
 type Fix =
     { FromRange : Text.Range

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fs
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fs
@@ -16,11 +16,12 @@ type AnalyzerAttribute([<Optional; DefaultParameterValue "Analyzer">] name: stri
   member _.Name = name
 
 type Context =
-    { FileName: string
+    { ParseFileResults: FSharpParseFileResults
+      CheckFileResults: FSharpCheckFileResults
+      CheckProjectResults: FSharpCheckProjectResults
+      FileName: string
       Content: string[]
-      ParseTree: ParsedInput
       TypedTree: FSharpImplementationFileContents
-      Symbols: FSharpEntity list
       GetAllEntities: bool -> AssemblySymbol list
       AllSymbolUses: FSharpSymbolUse array
       SymbolUsesOfFile: FSharpSymbolUse array }


### PR DESCRIPTION
To make a lot of interesting analyzers possible, we need a bit more information in the context.
So let's add the symbol uses to it.