### PR TITLE
Extract release from ci yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   ci:
@@ -24,9 +30,3 @@ jobs:
 
       - name: Test
         run: dotnet test -c Release --no-build
-
-      - name: Push
-        if: startsWith(github.ref, 'refs/tags/v')
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: dotnet nuget push "**/*.nupkg" -s "https://api.nuget.org/v3/index.json" -k "$NUGET_API_KEY" --skip-duplicate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v2
+        with:
+          global-json-file: global.json
+
+      - name: Restore tools
+        run: dotnet tool restore
+
+      - name: Run Build
+        run: dotnet build -c Release --no-restore -maxCpuCount
+
+      - name: Get Changelog Entry
+        id: changelog_reader
+        uses: mindsers/changelog-reader-action@v1.1.0
+        with:
+          version: ${{ github.ref }}
+          path: ./CHANGELOG.md
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: bin/*.nupkg
+          token: ${{ secrets.GITHUB_TOKEN }}
+          body: ${{ steps.changelog_reader.outputs.log_entry }}
+
+      - name: Push packages
+        run: dotnet nuget push "bin/*.nupkg" -s "https://api.nuget.org/v3/index.json" -k  ${{ secrets.NUGET_KEY }} --skip-duplicate


### PR DESCRIPTION
- Extract's releasing from CI yaml so we can do github releases from changelogs
- Fixes the duplicate running of CI on PRs