### PR TITLE
don't process SDK dll itself

### DIFF
--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.Client.fs
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.Client.fs
@@ -75,6 +75,7 @@ module Client =
     if Directory.Exists dir then
       let analyzerAssemblies =
           Directory.GetFiles(dir, "*Analyzer*.dll", SearchOption.AllDirectories)
+          |> Array.filter(fun a -> not (a.EndsWith("FSharp.Analyzers.SDK.dll")))
           |> Array.choose (fun analyzerDll ->
             try
               // loads an assembly and all of it's dependencies


### PR DESCRIPTION
Now with the filter/error reporting regarding mismatched referenced SDK versions from [72](https://github.com/ionide/FSharp.Analyzers.SDK/pull/72), loading and processing the SDK dll itself is not a good idea as the `Array.find` call in the filter throws with it.