### PR TITLE
Don't filter out .fsi files

### DIFF
--- a/src/FSharp.Analyzers.Cli/Program.fs
+++ b/src/FSharp.Analyzers.Cli/Program.fs
@@ -146,13 +146,6 @@ let runProject toolsPath proj (globs: Glob list) =
 
     opts.SourceFiles
     |> Array.filter (fun file ->
-        match Path.GetExtension(file).ToLowerInvariant() with
-        | ".fsi" ->
-            printInfo $"Ignoring signature file %s{file}"
-            false
-        | _ -> true
-    )
-    |> Array.filter (fun file ->
         match globs |> List.tryFind (fun g -> g.IsMatch file) with
         | Some g ->
             printInfo $"Ignoring file %s{file} for pattern %s{g.Pattern}"


### PR DESCRIPTION
fixes #78 
Let the analyzer decide whether to process .fsi files or not