### PR TITLE
Revisit Context type

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "fsdocs-tool": {
-      "version": "19.0.0",
+      "version": "19.1.0",
       "commands": [
         "fsdocs"
       ]

--- a/docs/content/Dual Analyzer.fsx
+++ b/docs/content/Dual Analyzer.fsx
@@ -1,0 +1,94 @@
+﻿(**
+---
+category: end-users
+categoryindex: 1
+index: 2
+---
+
+# Writing an analyzer for both console and editor
+
+With a little orchestration is it possible to easily write two analyzer functions that share a common implementation.
+
+*)
+
+(*** hide ***)
+#r "../../src/FSharp.Analyzers.Cli/bin/Release/net6.0/FSharp.Analyzers.SDK.dll"
+#r "../../src/FSharp.Analyzers.Cli/bin/Release/net6.0/FSharp.Compiler.Service.dll"
+(** *)
+
+open FSharp.Analyzers.SDK
+open FSharp.Compiler.Text
+open FSharp.Compiler.Syntax
+
+/// This analyzer function will try and detect if any `System.*` open statement was found after any non System open.
+/// See https://learn.microsoft.com/en-us/dotnet/fsharp/style-guide/conventions#sort-open-statements-topologically
+/// Note that this implementation is not complete and only serves as an illustration.
+/// Nested modules are not taking into account.
+let private topologicallySortedOpenStatementsAnalyzer (untypedTree: ParsedInput) : Message list =
+    let allOpenStatements =
+        let allOpenStatements = ResizeArray<string * range>()
+
+        let (|LongIdentAsString|) (lid: SynLongIdent) =
+            lid.LongIdent |> List.map (fun ident -> ident.idText) |> String.concat "."
+
+        let rec visitSynModuleSigDecl (decl: SynModuleSigDecl) =
+            match decl with
+            | SynModuleSigDecl.Open(SynOpenDeclTarget.ModuleOrNamespace(longId = LongIdentAsString value), mOpen) ->
+                allOpenStatements.Add(value, mOpen)
+            | _ -> ()
+
+        let rec visitSynModuleDecl (decl: SynModuleDecl) =
+            match decl with
+            | SynModuleDecl.Open(SynOpenDeclTarget.ModuleOrNamespace(longId = LongIdentAsString value), mOpen) ->
+                allOpenStatements.Add(value, mOpen)
+            | _ -> ()
+
+        match untypedTree with
+        | ParsedInput.SigFile(ParsedSigFileInput(contents = contents)) ->
+            for SynModuleOrNamespaceSig(decls = decls) in contents do
+                for decl in decls do
+                    visitSynModuleSigDecl decl
+
+        | ParsedInput.ImplFile(ParsedImplFileInput(contents = contents)) ->
+            for SynModuleOrNamespace(decls = decls) in contents do
+                for decl in decls do
+                    visitSynModuleDecl decl
+
+        allOpenStatements |> Seq.toList
+
+    let isOpenStatement (openStatement: string, _) = openStatement.StartsWith("System")
+
+    let nonSystemOpens = allOpenStatements |> List.skipWhile isOpenStatement
+
+    nonSystemOpens
+    |> List.filter isOpenStatement
+    |> List.map (fun (openStatement, mOpen) ->
+        {
+            Type = "Unsorted System open statement"
+            Message = $"%s{openStatement} was found after non System namespaces where opened!"
+            Code = "SOT001"
+            Severity = Warning
+            Range = mOpen
+            Fixes = []
+        }
+    )
+
+[<CliAnalyzer "Topologically sorted open statements">]
+let cliAnalyzer (ctx: CliContext) =
+    topologicallySortedOpenStatementsAnalyzer ctx.ParseFileResults.ParseTree
+
+[<EditorAnalyzer "Topologically sorted open statements">]
+let editorAnalyzer (ctx: EditorContext) =
+    match ctx.ParseFileResults with
+    // The editor might not have any parse results for a given file. So we don't return any messages.
+    | None -> []
+    | Some parseResults -> topologicallySortedOpenStatementsAnalyzer parseResults.ParseTree
+
+(**
+Both analyzer will follow the same code path: the console application will always have the required data, while the editor needs to be more careful.  
+⚠️ Please do not be tempted by calling `.Value` on the `EditorContext` 😉.
+
+
+[Previous]({{fsdocs-previous-page-link}})
+[Next]({{fsdocs-next-page-link}})
+*)

--- a/docs/content/Dual Analyzer.fsx
+++ b/docs/content/Dual Analyzer.fsx
@@ -7,7 +7,7 @@ index: 2
 
 # Writing an analyzer for both console and editor
 
-With a little orchestration is it possible to easily write two analyzer functions that share a common implementation.
+With a little orchestration it is possible to easily write two analyzer functions that share a common implementation.
 
 *)
 
@@ -23,7 +23,7 @@ open FSharp.Compiler.Syntax
 /// This analyzer function will try and detect if any `System.*` open statement was found after any non System open.
 /// See https://learn.microsoft.com/en-us/dotnet/fsharp/style-guide/conventions#sort-open-statements-topologically
 /// Note that this implementation is not complete and only serves as an illustration.
-/// Nested modules are not taking into account.
+/// Nested modules are not taken into account.
 let private topologicallySortedOpenStatementsAnalyzer (untypedTree: ParsedInput) : Async<Message list> =
     async {
         let allOpenStatements =
@@ -88,7 +88,7 @@ let editorAnalyzer (ctx: EditorContext) : Async<Message list> =
     | Some parseResults -> topologicallySortedOpenStatementsAnalyzer parseResults.ParseTree
 
 (**
-Both analyzer will follow the same code path: the console application will always have the required data, while the editor needs to be more careful.  
+Both analyzers will follow the same code path: the console application will always have the required data, while the editor needs to be more careful.  
 ⚠️ Please do not be tempted by calling `.Value` on the `EditorContext` 😉.
 
 [Previous]({{fsdocs-previous-page-link}})

--- a/docs/content/Dual Analyzer.fsx
+++ b/docs/content/Dual Analyzer.fsx
@@ -24,70 +24,72 @@ open FSharp.Compiler.Syntax
 /// See https://learn.microsoft.com/en-us/dotnet/fsharp/style-guide/conventions#sort-open-statements-topologically
 /// Note that this implementation is not complete and only serves as an illustration.
 /// Nested modules are not taking into account.
-let private topologicallySortedOpenStatementsAnalyzer (untypedTree: ParsedInput) : Message list =
-    let allOpenStatements =
-        let allOpenStatements = ResizeArray<string * range>()
+let private topologicallySortedOpenStatementsAnalyzer (untypedTree: ParsedInput) : Async<Message list> =
+    async {
+        let allOpenStatements =
+            let allOpenStatements = ResizeArray<string * range>()
 
-        let (|LongIdentAsString|) (lid: SynLongIdent) =
-            lid.LongIdent |> List.map (fun ident -> ident.idText) |> String.concat "."
+            let (|LongIdentAsString|) (lid: SynLongIdent) =
+                lid.LongIdent |> List.map (fun ident -> ident.idText) |> String.concat "."
 
-        let rec visitSynModuleSigDecl (decl: SynModuleSigDecl) =
-            match decl with
-            | SynModuleSigDecl.Open(SynOpenDeclTarget.ModuleOrNamespace(longId = LongIdentAsString value), mOpen) ->
-                allOpenStatements.Add(value, mOpen)
-            | _ -> ()
+            let rec visitSynModuleSigDecl (decl: SynModuleSigDecl) =
+                match decl with
+                | SynModuleSigDecl.Open(SynOpenDeclTarget.ModuleOrNamespace(longId = LongIdentAsString value), mOpen) ->
+                    allOpenStatements.Add(value, mOpen)
+                | _ -> ()
 
-        let rec visitSynModuleDecl (decl: SynModuleDecl) =
-            match decl with
-            | SynModuleDecl.Open(SynOpenDeclTarget.ModuleOrNamespace(longId = LongIdentAsString value), mOpen) ->
-                allOpenStatements.Add(value, mOpen)
-            | _ -> ()
+            let rec visitSynModuleDecl (decl: SynModuleDecl) =
+                match decl with
+                | SynModuleDecl.Open(SynOpenDeclTarget.ModuleOrNamespace(longId = LongIdentAsString value), mOpen) ->
+                    allOpenStatements.Add(value, mOpen)
+                | _ -> ()
 
-        match untypedTree with
-        | ParsedInput.SigFile(ParsedSigFileInput(contents = contents)) ->
-            for SynModuleOrNamespaceSig(decls = decls) in contents do
-                for decl in decls do
-                    visitSynModuleSigDecl decl
+            match untypedTree with
+            | ParsedInput.SigFile(ParsedSigFileInput(contents = contents)) ->
+                for SynModuleOrNamespaceSig(decls = decls) in contents do
+                    for decl in decls do
+                        visitSynModuleSigDecl decl
 
-        | ParsedInput.ImplFile(ParsedImplFileInput(contents = contents)) ->
-            for SynModuleOrNamespace(decls = decls) in contents do
-                for decl in decls do
-                    visitSynModuleDecl decl
+            | ParsedInput.ImplFile(ParsedImplFileInput(contents = contents)) ->
+                for SynModuleOrNamespace(decls = decls) in contents do
+                    for decl in decls do
+                        visitSynModuleDecl decl
 
-        allOpenStatements |> Seq.toList
+            allOpenStatements |> Seq.toList
 
-    let isOpenStatement (openStatement: string, _) = openStatement.StartsWith("System")
+        let isOpenStatement (openStatement: string, _) = openStatement.StartsWith("System")
 
-    let nonSystemOpens = allOpenStatements |> List.skipWhile isOpenStatement
+        let nonSystemOpens = allOpenStatements |> List.skipWhile isOpenStatement
 
-    nonSystemOpens
-    |> List.filter isOpenStatement
-    |> List.map (fun (openStatement, mOpen) ->
-        {
-            Type = "Unsorted System open statement"
-            Message = $"%s{openStatement} was found after non System namespaces where opened!"
-            Code = "SOT001"
-            Severity = Warning
-            Range = mOpen
-            Fixes = []
-        }
-    )
+        return
+            nonSystemOpens
+            |> List.filter isOpenStatement
+            |> List.map (fun (openStatement, mOpen) ->
+                {
+                    Type = "Unsorted System open statement"
+                    Message = $"%s{openStatement} was found after non System namespaces where opened!"
+                    Code = "SOT001"
+                    Severity = Warning
+                    Range = mOpen
+                    Fixes = []
+                }
+            )
+    }
 
 [<CliAnalyzer "Topologically sorted open statements">]
-let cliAnalyzer (ctx: CliContext) =
+let cliAnalyzer (ctx: CliContext) : Async<Message list> =
     topologicallySortedOpenStatementsAnalyzer ctx.ParseFileResults.ParseTree
 
 [<EditorAnalyzer "Topologically sorted open statements">]
-let editorAnalyzer (ctx: EditorContext) =
+let editorAnalyzer (ctx: EditorContext) : Async<Message list> =
     match ctx.ParseFileResults with
     // The editor might not have any parse results for a given file. So we don't return any messages.
-    | None -> []
+    | None -> async.Return []
     | Some parseResults -> topologicallySortedOpenStatementsAnalyzer parseResults.ParseTree
 
 (**
 Both analyzer will follow the same code path: the console application will always have the required data, while the editor needs to be more careful.  
 ⚠️ Please do not be tempted by calling `.Value` on the `EditorContext` 😉.
-
 
 [Previous]({{fsdocs-previous-page-link}})
 [Next]({{fsdocs-next-page-link}})

--- a/docs/content/Getting Started.fsx
+++ b/docs/content/Getting Started.fsx
@@ -36,11 +36,11 @@ There are two flavours of analyzers:
 - Editor analyzers ([EditorAnalyzer](../reference/fsharp-analyzers-sdk-editoranalyzerattribute.html))
 
 The key difference between them is that the console application analyzer will have the *full project* information.  
-Per file this included the untyped tree, typed tree, type-check results of the file and project type-check results.  
+Per file this includes the untyped tree, typed tree, type-check results of the file and project type-check results.  
 The [fsharp-analyzers](https://www.nuget.org/packages/fsharp-analyzers) tool will collect all this information upfront and pass it down to the analyzer via the [CliContext](../reference/fsharp-analyzers-sdk-clicontext.html).
 
 In the case of an editor analyzer, the IDE might not have all the available information available and will be more selective in what it can pass down to the analyzer.
-The main reasoning behind this is performance. It might be desirable for some analyzers to run after every keystroke, while other should be executed more sparingly.
+The main reasoning behind this is performance. It might be desirable for some analyzers to run after every keystroke, while others should be executed more sparingly.
 
 In the following example we will be 
 *)
@@ -79,7 +79,7 @@ module OptionAnalyzer =
 ## Running your first analyzer
 
 After building your project you can run your analyzer on a project of your choosing using the [fsharp-analyzers](https://www.nuget.org/packages/fsharp-analyzers) tool.  
-Please again verify your analyzer is a `CliAnalyzerAttribute` and uses the `CliContext`!
+Again, please verify your analyzer is a `CliAnalyzerAttribute` and uses the `CliContext`!
 
 ```shell
 dotnet tool install --global fsharp-analyzers

--- a/docs/content/Getting Started.fsx
+++ b/docs/content/Getting Started.fsx
@@ -29,7 +29,20 @@ paket add FSharp.Analyzers.SDK
 
 ## First analyzer
 
-An [Analyzer](../reference/fsharp-analyzers-sdk-analyzer.html) is a function that takes a `Context` and returns a list of `Message`.
+An [Analyzer<'TContext>](../reference/fsharp-analyzers-sdk-analyzer-1.html) is a function that takes a `Context` and returns a list of `Message`.  
+There are two flavours of analyzers:
+
+- Console application analyzers ([CliAnalyzer](../reference/fsharp-analyzers-sdk-clianalyzerattribute.html))
+- Editor analyzers ([EditorAnalyzer](../reference/fsharp-analyzers-sdk-editoranalyzerattribute.html))
+
+The key difference between them is that the console application analyzer will have the *full project* information.  
+Per file this included the untyped tree, typed tree, type-check results of the file and project type-check results.  
+The [fsharp-analyzers](https://www.nuget.org/packages/fsharp-analyzers) tool will collect all this information upfront and pass it down to the analyzer via the [CliContext](../reference/fsharp-analyzers-sdk-clicontext.html).
+
+In the case of an editor analyzer, the IDE might not have all the available information available and will be more selective in what it can pass down to the analyzer.
+The main reasoning behind this is performance. It might be desirable for some analyzers to run after every keystroke, while other should be executed more sparingly.
+
+In the following example we will be 
 *)
 
 (*** hide ***)
@@ -41,10 +54,10 @@ module OptionAnalyzer =
 
     open FSharp.Analyzers.SDK
 
-    // This attribute is required!
-    [<Analyzer>]
-    let optionValueAnalyzer: Analyzer =
-        fun (context: Context) ->
+    // This attribute is required and needs to match the correct context type!
+    [<CliAnalyzer>]
+    let optionValueAnalyzer: Analyzer<CliContext> =
+        fun (context: CliContext) ->
             // inspect context to determine the error/warning messages
             // A potential implementation might traverse the untyped syntax tree
             // to find any references of `Option.Value`
@@ -62,7 +75,8 @@ module OptionAnalyzer =
 (**
 ## Running your first analyzer
 
-After building your project you can run your analyzer on a project of your choosing using the [fsharp-analyzers](https://www.nuget.org/packages/fsharp-analyzers) tool.
+After building your project you can run your analyzer on a project of your choosing using the [fsharp-analyzers](https://www.nuget.org/packages/fsharp-analyzers) tool.  
+Please again verify your analyzer is a `CliAnalyzerAttribute` and uses the `CliContext`!
 
 ```shell
 dotnet tool install --global fsharp-analyzers
@@ -71,4 +85,7 @@ dotnet tool install --global fsharp-analyzers
 ```shell
 fsharp-analyzers --project YourProject.fsproj --analyzers-path ./OptionAnalyzer/bin/Release --verbose
 ```
+
+[Next]({{fsdocs-next-page-link}})
+
 *)

--- a/docs/content/Getting Started.fsx
+++ b/docs/content/Getting Started.fsx
@@ -58,19 +58,22 @@ module OptionAnalyzer =
     [<CliAnalyzer>]
     let optionValueAnalyzer: Analyzer<CliContext> =
         fun (context: CliContext) ->
-            // inspect context to determine the error/warning messages
-            // A potential implementation might traverse the untyped syntax tree
-            // to find any references of `Option.Value`
-            [
-                {
-                    Type = "Option.Value analyzer"
-                    Message = "Option.Value shouldn't be used"
-                    Code = "OV001"
-                    Severity = Warning
-                    Range = FSharp.Compiler.Text.Range.Zero
-                    Fixes = []
-                }
-            ]
+            async {
+                // inspect context to determine the error/warning messages
+                // A potential implementation might traverse the untyped syntax tree
+                // to find any references of `Option.Value`
+                return
+                    [
+                        {
+                            Type = "Option.Value analyzer"
+                            Message = "Option.Value shouldn't be used"
+                            Code = "OV001"
+                            Severity = Warning
+                            Range = FSharp.Compiler.Text.Range.Zero
+                            Fixes = []
+                        }
+                    ]
+            }
 
 (**
 ## Running your first analyzer

--- a/docs/content/Programmatic access.fsx
+++ b/docs/content/Programmatic access.fsx
@@ -1,0 +1,29 @@
+﻿(**
+---
+category: end-users
+categoryindex: 1
+index: 3
+---
+
+# Programmatically running an analyzer
+
+Using the [SDK](https://www.nuget.org/packages/FSharp.Analyzers.SDK), it is possible to invoke analyzers programmatically.  
+This can can done via the [Client](../reference/fsharp-analyzers-sdk-client-2.html) type.  
+The `Client` needs to know what type of analyzer you intend on loader: *console* or *editor*.
+*)
+
+(*** hide ***)
+#r "../../src/FSharp.Analyzers.Cli/bin/Release/net6.0/FSharp.Analyzers.SDK.dll"
+#r "../../src/FSharp.Analyzers.Cli/bin/Release/net6.0/FSharp.Compiler.Service.dll"
+(** *)
+
+open FSharp.Analyzers.SDK
+
+let client = Client<CliAnalyzerAttribute, CliContext>()
+let countLoaded = client.LoadAnalyzers ignore @"C:\MyAnalyzers"
+let ctx = Unchecked.defaultof<CliContext> // Construct your context...
+client.RunAnalyzers(ctx)
+
+(**
+[Previous]({{fsdocs-previous-page-link}})
+*)

--- a/docs/content/Programmatic access.fsx
+++ b/docs/content/Programmatic access.fsx
@@ -8,8 +8,8 @@ index: 3
 # Programmatically running an analyzer
 
 Using the [SDK](https://www.nuget.org/packages/FSharp.Analyzers.SDK), it is possible to invoke analyzers programmatically.  
-This can can done via the [Client](../reference/fsharp-analyzers-sdk-client-2.html) type.  
-The `Client` needs to know what type of analyzer you intend on loader: *console* or *editor*.
+This can be done via the [Client](../reference/fsharp-analyzers-sdk-client-2.html) type.  
+The `Client` needs to know what type of analyzer you intend to load: *console* or *editor*.
 *)
 
 (*** hide ***)

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,8 +30,8 @@ module BadCodeAnalyzer
 open FSharp.Analyzers.SDK
 
 [<Analyzer>]
-let badCodeAnalyzer : Analyzer =
-  fun (context: Context) ->
+let badCodeAnalyzer : Analyzer<CliContext> =
+  fun (context: CliContext) ->
     // inspect context to determine the error/warning messages
     [   ]
 ```
@@ -40,8 +40,8 @@ Notice how we expose the function `BadCodeAnalyzer.badCodeAnalyzer` with an attr
 Analyzers can also be named which allows for better logging if something went wrong while using the SDK from Ionide:
 ```fs
 [<Analyzer "BadCodeAnalyzer">]
-let badCodeAnalyzer : Analyzer =
-  fun (context: Context) ->
+let badCodeAnalyzer : Analyzer<CliContext> =
+  fun (context: CliContext) ->
     // inspect context to determine the error/warning messages
     [   ]
 ```
@@ -137,3 +137,5 @@ The project is hosted on [GitHub](https://github.com/Krzysztof-Cieslak/FSharp.An
 the project and submit pull requests.
 
 The library is available under [MIT license](https://github.com/Krzysztof-Cieslak/FSharp.Analyzers.SDK/blob/master/LICENSE.md), which allows modification and redistribution for both commercial and non-commercial purposes.
+
+[Next]({{fsdocs-next-page-link}})

--- a/docs/style.css
+++ b/docs/style.css
@@ -53,7 +53,7 @@
     --code-punctuation-color: #43AEC6;
     --code-punctuation2-color: var(--text-color);
     --code-function-color: #6B2FBA;
-    --code-function2-color: #990000;
+    --code-function2-color: #6B2FBA;
     --code-activepattern-color: #4ec9b0;
     --code-unioncase-color: #4ec9b0;
     --code-enumeration-color: #8C6C41;
@@ -175,10 +175,10 @@ aside {
             list-style: none;
             font-size: var(--unit-3);
             color: var(--nav-category);
-        }
-
-        .nav-header + .nav-item {
-            margin-bottom: var(--unit-6);
+            
+            &:nth-child(n + 2) {
+                margin-top: var(--unit-6);
+            }
         }
 
         .nav-item {
@@ -187,7 +187,7 @@ aside {
             margin: var(--unit-2) 0;
             border-left: 1px solid var(--header-border);
             transition: border-color 200ms;
-
+            
             &:hover {
                 border-color: var(--text-color);
             }
@@ -379,6 +379,39 @@ a {
     color: var(--link-color);
 }
 
+p {
+    line-height: 1.8;
+}
+
+/* Navigation links at the end of a page */
+#fsdocs-content > p:last-of-type {
+    display: flex;
+    justify-content: center;
+    margin-top: var(--unit-6);
+    
+    &:has(a + a) {
+        justify-content: space-between;
+    }
+    
+    > a {
+        text-decoration: none;
+        background: var(--menu-icon-hover-background);
+        color: var(--code-background);
+        padding: var(--unit) var(--unit-2);
+        margin: 0;
+        display: inline-block;
+        box-sizing: border-box;
+        border-radius: var(--radius);
+
+        &:hover {
+            background-color: var(--nav-category);
+        }
+
+        &:focus {
+            color: var(--text-color);
+        }
+    }
+}
 /* Code snippets */
 
 /* reset browser style */
@@ -402,8 +435,8 @@ table.pre, pre.fssnip {
 }
 
 p > code, li > code {
-    margin: 0 var(--unit);
     padding: var(--unit);
+    transform: translateY(var(--unit));
 }
 
 table.pre, code {

--- a/docs/tooltips.js
+++ b/docs/tooltips.js
@@ -7,21 +7,6 @@ function hideTip(evt, name, unique) {
     currentTip = null;
 }
 
-function findPos(obj) {
-    // no idea why, but it behaves differently in webbrowser component
-    if (window.location.search === "?inapp")
-        return [obj.offsetLeft + 10, obj.offsetTop + 30];
-
-    let curleft = 0;
-    let curtop = obj.offsetHeight;
-    while (obj) {
-        curleft += obj.offsetLeft;
-        curtop += obj.offsetTop;
-        obj = obj.offsetParent;
-    }
-    return [curleft, curtop];
-}
-
 function hideUsingEsc(e) {
     hideTip(e, currentTipElement, currentTip);
 }
@@ -32,15 +17,27 @@ function showTip(evt, name, unique, owner) {
     currentTip = unique;
     currentTipElement = name;
 
-    let pos = findPos(owner ? owner : (evt.srcElement ? evt.srcElement : evt.target));
-    const posx = pos[0];
-    const posy = pos[1];
+    const offset = 20;
+    let x = evt.clientX;
+    let y = evt.clientY + offset;
 
     const el = document.getElementById(name);
     el.style.position = "absolute";
-    el.style.left = posx + "px";
-    el.style.top = posy + "px";
     el.style.display = "block";
+    el.style.left = `${x}px`;
+    el.style.top = `${y}px`;
+
+    const rect =  el.getBoundingClientRect();
+    // Move tooltip if it is out of sight
+    if(rect.bottom > window.innerHeight) {
+        y = y - el.clientHeight - offset;
+        el.style.top = `${y}px`;
+    }
+    
+    if (rect.right > window.innerWidth) {
+        x = y - el.clientWidth - offset;
+        el.style.left = `${x}px`;
+    }
 }
 
 function Clipboard_CopyTo(value) {

--- a/samples/OptionAnalyzer/Library.fs
+++ b/samples/OptionAnalyzer/Library.fs
@@ -112,25 +112,28 @@ let notUsed () =
 [<CliAnalyzer "OptionAnalyzer">]
 let optionValueAnalyzer: Analyzer<CliContext> =
     fun ctx ->
-        let state = ResizeArray<range>()
+        async {
+            let state = ResizeArray<range>()
 
-        let handler (range: range) (m: FSharpMemberOrFunctionOrValue) =
-            let name = String.Join(".", m.DeclaringEntity.Value.FullName, m.DisplayName)
+            let handler (range: range) (m: FSharpMemberOrFunctionOrValue) =
+                let name = String.Join(".", m.DeclaringEntity.Value.FullName, m.DisplayName)
 
-            if name = "Microsoft.FSharp.Core.FSharpOption`1.Value" then
-                state.Add range
+                if name = "Microsoft.FSharp.Core.FSharpOption`1.Value" then
+                    state.Add range
 
-        ctx.TypedTree.Declarations |> List.iter (visitDeclaration handler)
+            ctx.TypedTree.Declarations |> List.iter (visitDeclaration handler)
 
-        state
-        |> Seq.map (fun r ->
-            {
-                Type = "Option.Value analyzer"
-                Message = "Option.Value shouldn't be used"
-                Code = "OV001"
-                Severity = Warning
-                Range = r
-                Fixes = []
-            }
-        )
-        |> Seq.toList
+            return
+                state
+                |> Seq.map (fun r ->
+                    {
+                        Type = "Option.Value analyzer"
+                        Message = "Option.Value shouldn't be used"
+                        Code = "OV001"
+                        Severity = Warning
+                        Range = r
+                        Fixes = []
+                    }
+                )
+                |> Seq.toList
+        }

--- a/samples/OptionAnalyzer/Library.fs
+++ b/samples/OptionAnalyzer/Library.fs
@@ -109,8 +109,8 @@ let notUsed () =
     let option: Option<int> = None
     option.Value
 
-[<Analyzer "OptionAnalyzer">]
-let optionValueAnalyzer: Analyzer =
+[<CliAnalyzer "OptionAnalyzer">]
+let optionValueAnalyzer: Analyzer<CliContext> =
     fun ctx ->
         let state = ResizeArray<range>()
 

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.Client.fsi
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.Client.fsi
@@ -18,5 +18,5 @@ type Client<'TAttribute, 'TContext when 'TAttribute :> AnalyzerAttribute and 'TC
     /// <returns>list of messages. Ignores errors from the analyzers</returns>
     member RunAnalyzers: ctx: 'TContext -> Async<Message list>
     /// <summary>Runs all registered analyzers for given context (file).</summary>
-    /// <returns>list of results per analyzer which can either messages or an exception.</returns>
+    /// <returns>list of results per analyzer which can either be messages or an exception.</returns>
     member RunAnalyzersSafely: ctx: 'TContext -> Async<AnalysisResult list>

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.Client.fsi
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.Client.fsi
@@ -16,7 +16,7 @@ type Client<'TAttribute, 'TContext when 'TAttribute :> AnalyzerAttribute and 'TC
     member LoadAnalyzers: printError: (string -> unit) -> dir: string -> int * int
     /// <summary>Runs all registered analyzers for given context (file).</summary>
     /// <returns>list of messages. Ignores errors from the analyzers</returns>
-    member RunAnalyzers: ctx: 'TContext -> Message array
+    member RunAnalyzers: ctx: 'TContext -> Async<Message list>
     /// <summary>Runs all registered analyzers for given context (file).</summary>
     /// <returns>list of results per analyzer which can either messages or an exception.</returns>
-    member RunAnalyzersSafely: ctx: 'TContext -> AnalysisResult list
+    member RunAnalyzersSafely: ctx: 'TContext -> Async<AnalysisResult list>

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.Client.fsi
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.Client.fsi
@@ -1,0 +1,24 @@
+namespace FSharp.Analyzers.SDK
+
+open System.Collections.Concurrent
+
+type AnalysisResult =
+    {
+        AnalyzerName: string
+        Output: Result<Message list, exn>
+    }
+
+module Client =
+    val registeredAnalyzers: ConcurrentDictionary<string, (string * Analyzer) list>
+    /// <summary>
+    /// Loads into private state any analyzers defined in any assembly
+    /// matching `*Analyzer*.dll` in given directory (and any subdirectories)
+    /// </summary>
+    /// <returns>number of found dlls matching `*Analyzer*.dll` and number of registered analyzers</returns>
+    val loadAnalyzers: printError: (string -> unit) -> dir: string -> int * int
+    /// <summary>Runs all registered analyzers for given context (file).</summary>
+    /// <returns>list of messages. Ignores errors from the analyzers</returns>
+    val runAnalyzers: ctx: Context -> Message array
+    /// <summary>Runs all registered analyzers for given context (file).</summary>
+    /// <returns>list of results per analyzer which can ei</returns>
+    val runAnalyzersSafely: ctx: Context -> AnalysisResult list

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.Client.fsi
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.Client.fsi
@@ -1,24 +1,22 @@
 namespace FSharp.Analyzers.SDK
 
-open System.Collections.Concurrent
-
 type AnalysisResult =
     {
         AnalyzerName: string
         Output: Result<Message list, exn>
     }
 
-module Client =
-    val registeredAnalyzers: ConcurrentDictionary<string, (string * Analyzer) list>
+type Client<'TAttribute, 'TContext when 'TAttribute :> AnalyzerAttribute and 'TContext :> Context> =
+    new: unit -> Client<'TAttribute, 'TContext>
     /// <summary>
     /// Loads into private state any analyzers defined in any assembly
     /// matching `*Analyzer*.dll` in given directory (and any subdirectories)
     /// </summary>
     /// <returns>number of found dlls matching `*Analyzer*.dll` and number of registered analyzers</returns>
-    val loadAnalyzers: printError: (string -> unit) -> dir: string -> int * int
+    member LoadAnalyzers: printError: (string -> unit) -> dir: string -> int * int
     /// <summary>Runs all registered analyzers for given context (file).</summary>
     /// <returns>list of messages. Ignores errors from the analyzers</returns>
-    val runAnalyzers: ctx: Context -> Message array
+    member RunAnalyzers: ctx: 'TContext -> Message array
     /// <summary>Runs all registered analyzers for given context (file).</summary>
-    /// <returns>list of results per analyzer which can ei</returns>
-    val runAnalyzersSafely: ctx: Context -> AnalysisResult list
+    /// <returns>list of results per analyzer which can either messages or an exception.</returns>
+    member RunAnalyzersSafely: ctx: 'TContext -> AnalysisResult list

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fs
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fs
@@ -91,8 +91,8 @@ type CliContext =
 type EditorContext =
     {
         FileName: string
-        SourceText: ISourceText option
-        ParseFileResults: FSharpParseFileResults option
+        SourceText: ISourceText
+        ParseFileResults: FSharpParseFileResults
         CheckFileResults: FSharpCheckFileResults option
         TypedTree: FSharpImplementationFileContents option
         CheckProjectResults: FSharpCheckProjectResults option

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fs
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fs
@@ -124,6 +124,7 @@ type Fix =
 
 type Severity =
     | Info
+    | Hint
     | Warning
     | Error
 

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fs
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fs
@@ -138,4 +138,4 @@ type Message =
         Fixes: Fix list
     }
 
-type Analyzer<'TContext> = 'TContext -> Message list
+type Analyzer<'TContext> = 'TContext -> Async<Message list>

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fs
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fs
@@ -1,12 +1,14 @@
 namespace FSharp.Analyzers.SDK
 
 open System
-open FSharp.Compiler
 open FSharp.Compiler.CodeAnalysis
-open FSharp.Compiler.Syntax
 open FSharp.Compiler.Symbols
 open FSharp.Compiler.EditorServices
 open System.Runtime.InteropServices
+open FSharp.Compiler.Text
+
+module EntityCache =
+    let entityCache = EntityCache()
 
 /// Marks an analyzer for scanning
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property ||| AttributeTargets.Field)>]
@@ -17,20 +19,65 @@ type AnalyzerAttribute([<Optional; DefaultParameterValue "Analyzer">] name: stri
 
 type Context =
     {
+        FileName: string
+        SourceText: ISourceText
         ParseFileResults: FSharpParseFileResults
         CheckFileResults: FSharpCheckFileResults
-        CheckProjectResults: FSharpCheckProjectResults
-        FileName: string
-        Content: string[]
         TypedTree: FSharpImplementationFileContents
-        GetAllEntities: bool -> AssemblySymbol list
-        AllSymbolUses: FSharpSymbolUse array
-        SymbolUsesOfFile: FSharpSymbolUse array
+        CheckProjectResults: Async<FSharpCheckProjectResults>
     }
+
+    member x.GetAllEntities(publicOnly: bool) =
+        try
+            let res =
+                [
+                    yield!
+                        AssemblyContent.GetAssemblySignatureContent
+                            AssemblyContentType.Full
+                            x.CheckFileResults.PartialAssemblySignature
+                    let ctx = x.CheckFileResults.ProjectContext
+
+                    let assembliesByFileName =
+                        ctx.GetReferencedAssemblies()
+                        |> Seq.groupBy (fun asm -> asm.FileName)
+                        |> Seq.map (fun (fileName, asms) -> fileName, List.ofSeq asms)
+                        |> Seq.toList
+                        |> List.rev // if mscorlib.dll is the first then FSC raises exception when we try to
+                    // get Content.Entities from it.
+
+                    for fileName, signatures in assembliesByFileName do
+                        let contentType =
+                            if publicOnly then
+                                AssemblyContentType.Public
+                            else
+                                AssemblyContentType.Full
+
+                        let content =
+                            AssemblyContent.GetAssemblyContent
+                                EntityCache.entityCache.Locking
+                                contentType
+                                fileName
+                                signatures
+
+                        yield! content
+                ]
+
+            res
+        with _ ->
+            []
+
+    member x.GetAllSymbolUsesOfProject() =
+        async {
+            let! checkProjectResults = x.CheckProjectResults
+            return checkProjectResults.GetAllUsesOfAllSymbols()
+        }
+
+    member x.GetAllSymbolUsesOfFile() =
+        x.CheckFileResults.GetAllUsesOfAllSymbolsInFile()
 
 type Fix =
     {
-        FromRange: Text.Range
+        FromRange: range
         FromText: string
         ToText: string
     }
@@ -46,7 +93,7 @@ type Message =
         Message: string
         Code: string
         Severity: Severity
-        Range: Text.Range
+        Range: range
         Fixes: Fix list
     }
 

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsi
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsi
@@ -49,7 +49,7 @@ type CliContext =
         /// Represents the definitional contents of a single file or fragment in an assembly, as seen by the F# language
         /// See <a href="https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-symbols-fsharpimplementationfilecontents.html">FSharpImplementationFileContents Type</a>
         TypedTree: FSharpImplementationFileContents
-        /// A handle the results of the entire project
+        /// A handle to the results of the entire project
         /// See <a href="https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-codeanalysis-fsharpcheckprojectresults.html">FSharpCheckProjectResults Type</a>
         CheckProjectResults: FSharpCheckProjectResults
     }
@@ -81,7 +81,7 @@ type EditorContext =
         /// Represents the definitional contents of a single file or fragment in an assembly, as seen by the F# language
         /// See <a href="https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-symbols-fsharpimplementationfilecontents.html">FSharpImplementationFileContents Type</a>
         TypedTree: FSharpImplementationFileContents option
-        /// A handle the results of the entire project
+        /// A handle to the results of the entire project
         /// See <a href="https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-codeanalysis-fsharpcheckprojectresults.html">FSharpCheckProjectResults Type</a>
         CheckProjectResults: FSharpCheckProjectResults option
     }

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsi
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsi
@@ -71,10 +71,10 @@ type EditorContext =
         FileName: string
         /// Source of the current file.
         /// See <a href="https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-text-isourcetext.html">ISourceText Type</a>
-        SourceText: ISourceText option
+        SourceText: ISourceText
         /// Represents the results of parsing an F# file and a set of analysis operations based on the parse tree alone.
         /// See <a href="https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-codeanalysis-fsharpparsefileresults.html">FSharpParseFileResults Type</a>
-        ParseFileResults: FSharpParseFileResults option
+        ParseFileResults: FSharpParseFileResults
         /// A handle to the results of CheckFileInProject.
         /// See <a href="https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-codeanalysis-fsharpcheckfileresults.html">FSharpCheckFileResults Type</a>
         CheckFileResults: FSharpCheckFileResults option

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsi
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsi
@@ -1,22 +1,39 @@
 namespace FSharp.Analyzers.SDK
 
 open System
+open System.Runtime.InteropServices
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Symbols
 open FSharp.Compiler.EditorServices
-open System.Runtime.InteropServices
 open FSharp.Compiler.Text
 
-/// Marks an analyzer for scanning
+[<AbstractClass>]
 [<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property ||| AttributeTargets.Field)>]
 type AnalyzerAttribute =
     new: [<Optional; DefaultParameterValue("Analyzer" :> obj)>] name: string -> AnalyzerAttribute
     inherit Attribute
     member Name: string
 
+/// Marks an analyzer for scanning during the console application run.
+type CliAnalyzerAttribute =
+    new: [<Optional; DefaultParameterValue("Analyzer" :> obj)>] name: string -> CliAnalyzerAttribute
+    inherit AnalyzerAttribute
+    member Name: string
+
+/// Marks an analyzer for scanning during IDE integration.
+type EditorAnalyzerAttribute =
+    new: [<Optional; DefaultParameterValue("Analyzer" :> obj)>] name: string -> EditorAnalyzerAttribute
+    inherit AnalyzerAttribute
+    member Name: string
+
+/// Marker interface which both the CliContext and EditorContext implement
+type Context =
+    interface
+    end
+
 /// All the relevant compiler information for a given file.
 /// Contains the source text, untyped and typed tree information.
-type Context =
+type CliContext =
     {
         /// The current file name.
         FileName: string
@@ -34,13 +51,47 @@ type Context =
         TypedTree: FSharpImplementationFileContents
         /// A handle the results of the entire project
         /// See <a href="https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-codeanalysis-fsharpcheckprojectresults.html">FSharpCheckProjectResults Type</a>
-        CheckProjectResults: Async<FSharpCheckProjectResults>
+        CheckProjectResults: FSharpCheckProjectResults
     }
+
+    interface Context
 
     /// Collects all the types found in the CheckFileResults
     member GetAllEntities: publicOnly: bool -> AssemblySymbol list
     /// Helper for CheckProjectResults.GetAllUsesOfAllSymbols
-    member GetAllSymbolUsesOfProject: unit -> Async<FSharpSymbolUse array>
+    member GetAllSymbolUsesOfProject: unit -> FSharpSymbolUse array
+    /// Helper for CheckFileResults.GetAllUsesOfAllSymbolsInFile
+    member GetAllSymbolUsesOfFile: unit -> FSharpSymbolUse seq
+
+/// Optional compiler information for a given file.
+/// The available contents is controlled based on what information the IDE has available.
+type EditorContext =
+    {
+        /// The current file name.
+        FileName: string
+        /// Source of the current file.
+        /// See <a href="https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-text-isourcetext.html">ISourceText Type</a>
+        SourceText: ISourceText option
+        /// Represents the results of parsing an F# file and a set of analysis operations based on the parse tree alone.
+        /// See <a href="https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-codeanalysis-fsharpparsefileresults.html">FSharpParseFileResults Type</a>
+        ParseFileResults: FSharpParseFileResults option
+        /// A handle to the results of CheckFileInProject.
+        /// See <a href="https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-codeanalysis-fsharpcheckfileresults.html">FSharpCheckFileResults Type</a>
+        CheckFileResults: FSharpCheckFileResults option
+        /// Represents the definitional contents of a single file or fragment in an assembly, as seen by the F# language
+        /// See <a href="https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-symbols-fsharpimplementationfilecontents.html">FSharpImplementationFileContents Type</a>
+        TypedTree: FSharpImplementationFileContents option
+        /// A handle the results of the entire project
+        /// See <a href="https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-codeanalysis-fsharpcheckprojectresults.html">FSharpCheckProjectResults Type</a>
+        CheckProjectResults: FSharpCheckProjectResults option
+    }
+
+    interface Context
+
+    /// Collects all the types found in the CheckFileResults
+    member GetAllEntities: publicOnly: bool -> AssemblySymbol list
+    /// Helper for CheckProjectResults.GetAllUsesOfAllSymbols
+    member GetAllSymbolUsesOfProject: unit -> FSharpSymbolUse array
     /// Helper for CheckFileResults.GetAllUsesOfAllSymbolsInFile
     member GetAllSymbolUsesOfFile: unit -> FSharpSymbolUse seq
 
@@ -66,4 +117,4 @@ type Message =
         Fixes: Fix list
     }
 
-type Analyzer = Context -> Message list
+type Analyzer<'TContext> = 'TContext -> Message list

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsi
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsi
@@ -104,6 +104,7 @@ type Fix =
 
 type Severity =
     | Info
+    | Hint
     | Warning
     | Error
 

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsi
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsi
@@ -1,0 +1,69 @@
+namespace FSharp.Analyzers.SDK
+
+open System
+open FSharp.Compiler.CodeAnalysis
+open FSharp.Compiler.Symbols
+open FSharp.Compiler.EditorServices
+open System.Runtime.InteropServices
+open FSharp.Compiler.Text
+
+/// Marks an analyzer for scanning
+[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property ||| AttributeTargets.Field)>]
+type AnalyzerAttribute =
+    new: [<Optional; DefaultParameterValue("Analyzer" :> obj)>] name: string -> AnalyzerAttribute
+    inherit Attribute
+    member Name: string
+
+/// All the relevant compiler information for a given file.
+/// Contains the source text, untyped and typed tree information.
+type Context =
+    {
+        /// The current file name.
+        FileName: string
+        /// Source of the current file.
+        /// See <a href="https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-text-isourcetext.html">ISourceText Type</a>
+        SourceText: ISourceText
+        /// Represents the results of parsing an F# file and a set of analysis operations based on the parse tree alone.
+        /// See <a href="https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-codeanalysis-fsharpparsefileresults.html">FSharpParseFileResults Type</a>
+        ParseFileResults: FSharpParseFileResults
+        /// A handle to the results of CheckFileInProject.
+        /// See <a href="https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-codeanalysis-fsharpcheckfileresults.html">FSharpCheckFileResults Type</a>
+        CheckFileResults: FSharpCheckFileResults
+        /// Represents the definitional contents of a single file or fragment in an assembly, as seen by the F# language
+        /// See <a href="https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-symbols-fsharpimplementationfilecontents.html">FSharpImplementationFileContents Type</a>
+        TypedTree: FSharpImplementationFileContents
+        /// A handle the results of the entire project
+        /// See <a href="https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-codeanalysis-fsharpcheckprojectresults.html">FSharpCheckProjectResults Type</a>
+        CheckProjectResults: Async<FSharpCheckProjectResults>
+    }
+
+    /// Collects all the types found in the CheckFileResults
+    member GetAllEntities: publicOnly: bool -> AssemblySymbol list
+    /// Helper for CheckProjectResults.GetAllUsesOfAllSymbols
+    member GetAllSymbolUsesOfProject: unit -> Async<FSharpSymbolUse array>
+    /// Helper for CheckFileResults.GetAllUsesOfAllSymbolsInFile
+    member GetAllSymbolUsesOfFile: unit -> FSharpSymbolUse seq
+
+type Fix =
+    {
+        FromRange: range
+        FromText: string
+        ToText: string
+    }
+
+type Severity =
+    | Info
+    | Warning
+    | Error
+
+type Message =
+    {
+        Type: string
+        Message: string
+        Code: string
+        Severity: Severity
+        Range: range
+        Fixes: Fix list
+    }
+
+type Analyzer = Context -> Message list

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsi
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsi
@@ -118,4 +118,4 @@ type Message =
         Fixes: Fix list
     }
 
-type Analyzer<'TContext> = 'TContext -> Message list
+type Analyzer<'TContext> = 'TContext -> Async<Message list>

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsproj
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsproj
@@ -12,7 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="FSharp.Analyzers.SDK.fsi" />
     <Compile Include="FSharp.Analyzers.SDK.fs" />
+    <Compile Include="FSharp.Analyzers.SDK.Client.fsi" />
     <Compile Include="FSharp.Analyzers.SDK.Client.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
A slight restructure of the `Context` type.
I think for now it should really expose all the base FCS primitives so people can do everything they need.

I've added some convenient members and we can expand upon that later.
I'm not quite sure yet about `CheckProjectResults: Async<FSharpCheckProjectResults>` yet.
As in should it be wrapped in `lazy` as well?

I quite like that `GetAllEntities`, `AllSymbolUses` and `SymbolUsesOfFile` are more on a demand basis.
Not all analyzers will require this.

Let me know what you think.