### PR TITLE
Make TypedTree optional in CliContext.

### DIFF
--- a/samples/OptionAnalyzer/Library.fs
+++ b/samples/OptionAnalyzer/Library.fs
@@ -121,7 +121,9 @@ let optionValueAnalyzer: Analyzer<CliContext> =
                 if name = "Microsoft.FSharp.Core.FSharpOption`1.Value" then
                     state.Add range
 
-            ctx.TypedTree.Declarations |> List.iter (visitDeclaration handler)
+            match ctx.TypedTree with
+            | None -> ()
+            | Some typedTree -> typedTree.Declarations |> List.iter (visitDeclaration handler)
 
             return
                 state

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fs
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fs
@@ -73,7 +73,7 @@ type CliContext =
         SourceText: ISourceText
         ParseFileResults: FSharpParseFileResults
         CheckFileResults: FSharpCheckFileResults
-        TypedTree: FSharpImplementationFileContents
+        TypedTree: FSharpImplementationFileContents option
         CheckProjectResults: FSharpCheckProjectResults
     }
 

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsi
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsi
@@ -46,9 +46,10 @@ type CliContext =
         /// A handle to the results of CheckFileInProject.
         /// See <a href="https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-codeanalysis-fsharpcheckfileresults.html">FSharpCheckFileResults Type</a>
         CheckFileResults: FSharpCheckFileResults
-        /// Represents the definitional contents of a single file or fragment in an assembly, as seen by the F# language
+        /// Represents the definitional contents of a single file or fragment in an assembly, as seen by the F# language.
+        /// Only available for implementation files.
         /// See <a href="https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-symbols-fsharpimplementationfilecontents.html">FSharpImplementationFileContents Type</a>
-        TypedTree: FSharpImplementationFileContents
+        TypedTree: FSharpImplementationFileContents option
         /// A handle to the results of the entire project
         /// See <a href="https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-codeanalysis-fsharpcheckprojectresults.html">FSharpCheckProjectResults Type</a>
         CheckProjectResults: FSharpCheckProjectResults


### PR DESCRIPTION
I was having some issues with the context being created for signature files.
`TypedTree` should be optional in this regard.