### PR TITLE
Exclude analyzers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+* [Exclude analyzers](https://github.com/ionide/FSharp.Analyzers.SDK/issues/112) (thanks @nojaf)
+
 ## [0.14.1] - 2023-09-26
 
 ### Changed

--- a/docs/content/Programmatic access.fsx
+++ b/docs/content/Programmatic access.fsx
@@ -20,7 +20,7 @@ The `Client` needs to know what type of analyzer you intend to load: *console* o
 open FSharp.Analyzers.SDK
 
 let client = Client<CliAnalyzerAttribute, CliContext>()
-let countLoaded = client.LoadAnalyzers ignore @"C:\MyAnalyzers"
+let countLoaded = client.LoadAnalyzers @"C:\MyAnalyzers"
 let ctx = Unchecked.defaultof<CliContext> // Construct your context...
 client.RunAnalyzers(ctx)
 

--- a/src/FSharp.Analyzers.Cli/Program.fs
+++ b/src/FSharp.Analyzers.Cli/Program.fs
@@ -23,7 +23,7 @@ type Arguments =
             | Fail_On_Warnings _ ->
                 "List of analyzer codes that should trigger tool failures in the presence of warnings."
             | Ignore_Files _ -> "Source files that shouldn't be processed."
-            | Exclude_Analyzer _ -> "The names of analyzer that should not be executed."
+            | Exclude_Analyzer _ -> "The names of analyzers that should not be executed."
             | Verbose -> "Verbose logging."
 
 let mutable verbose = false

--- a/src/FSharp.Analyzers.Cli/Program.fs
+++ b/src/FSharp.Analyzers.Cli/Program.fs
@@ -12,10 +12,19 @@ type Arguments =
     | Analyzers_Path of string
     | Fail_On_Warnings of string list
     | Ignore_Files of string list
+    | Exclude_Analyzer of string list
     | Verbose
 
     interface IArgParserTemplate with
-        member s.Usage = ""
+        member s.Usage =
+            match s with
+            | Project s -> "Path to your .fsproj file."
+            | Analyzers_Path _ -> "Path to a folder where your analyzers are located."
+            | Fail_On_Warnings _ ->
+                "List of analyzer codes that should trigger tool failures in the presence of warnings."
+            | Ignore_Files _ -> "Source files that shouldn't be processed."
+            | Exclude_Analyzer _ -> "The names of analyzer that should not be executed."
+            | Verbose -> "Verbose logging."
 
 let mutable verbose = false
 

--- a/src/FSharp.Analyzers.SDK.Testing/FSharp.Analyzers.SDK.Testing.fs
+++ b/src/FSharp.Analyzers.SDK.Testing/FSharp.Analyzers.SDK.Testing.fs
@@ -218,12 +218,11 @@ let getContext (opts: FSharpProjectOptions) source =
         Map.tryFind fileName files |> async.Return
 
     let fcs = Utils.createFCS (Some documentSource)
-    let printError (s: string) = Console.WriteLine(s)
     let pathToAnalyzerDlls = Path.GetFullPath(".")
 
     let foundDlls, registeredAnalyzers =
         let client = Client<CliAnalyzerAttribute, CliContext>()
-        client.LoadAnalyzers printError pathToAnalyzerDlls
+        client.LoadAnalyzers pathToAnalyzerDlls
 
     if foundDlls = 0 then
         failwith $"no Dlls found in {pathToAnalyzerDlls}"

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.Client.fs
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.Client.fs
@@ -178,13 +178,12 @@ type Client<'TAttribute, 'TContext when 'TAttribute :> AnalyzerAttribute and 'TC
 
                             not shouldExclude
                         )
+                        |> Seq.toList
 
                     path, analyzers
                 )
 
             for path, analyzers in analyzers do
-                let analyzers = Seq.toList analyzers
-
                 registeredAnalyzers.AddOrUpdate(path, analyzers, (fun _ _ -> analyzers))
                 |> ignore
 

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.Client.fs
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.Client.fs
@@ -31,8 +31,10 @@ module Client =
         let hasExpectReturnType (t: Type) =
             // t might be a System.RunTimeType as could have no FullName
             if not (isNull t.FullName) then
-                t.FullName.StartsWith
-                    "Microsoft.FSharp.Control.FSharpAsync`1[[Microsoft.FSharp.Collections.FSharpList`1[[FSharp.Analyzers.SDK.Message"
+                t.FullName.StartsWith(
+                    "Microsoft.FSharp.Control.FSharpAsync`1[[Microsoft.FSharp.Collections.FSharpList`1[[FSharp.Analyzers.SDK.Message",
+                    StringComparison.InvariantCulture
+                )
             elif t.Name = "FSharpAsync`1" && t.GenericTypeArguments.Length = 1 then
                 let listType = t.GenericTypeArguments.[0]
 
@@ -123,8 +125,12 @@ type Client<'TAttribute, 'TContext when 'TAttribute :> AnalyzerAttribute and 'TC
 
                 Directory.GetFiles(dir, "*Analyzer*.dll", SearchOption.AllDirectories)
                 |> Array.filter (fun a ->
-                    let s = Path.GetFileName(a).ToLowerInvariant()
-                    not (s.EndsWith("fsharp.analyzers.sdk.dll") || regex.IsMatch(s))
+                    let s = Path.GetFileName(a)
+
+                    not (
+                        s.EndsWith("fsharp.analyzers.sdk.dll", StringComparison.InvariantCultureIgnoreCase)
+                        || regex.IsMatch(s)
+                    )
                 )
                 |> Array.choose (fun analyzerDll ->
                     try

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.Client.fsi
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.Client.fsi
@@ -6,14 +6,20 @@ type AnalysisResult =
         Output: Result<Message list, exn>
     }
 
+[<Interface>]
+type Logger =
+    abstract member Error: string -> unit
+    abstract member Verbose: string -> unit
+
 type Client<'TAttribute, 'TContext when 'TAttribute :> AnalyzerAttribute and 'TContext :> Context> =
+    new: logger: Logger * excludedAnalyzers: string Set -> Client<'TAttribute, 'TContext>
     new: unit -> Client<'TAttribute, 'TContext>
     /// <summary>
     /// Loads into private state any analyzers defined in any assembly
     /// matching `*Analyzer*.dll` in given directory (and any subdirectories)
     /// </summary>
     /// <returns>number of found dlls matching `*Analyzer*.dll` and number of registered analyzers</returns>
-    member LoadAnalyzers: printError: (string -> unit) -> dir: string -> int * int
+    member LoadAnalyzers: dir: string -> int * int
     /// <summary>Runs all registered analyzers for given context (file).</summary>
     /// <returns>list of messages. Ignores errors from the analyzers</returns>
     member RunAnalyzers: ctx: 'TContext -> Async<Message list>


### PR DESCRIPTION
Example usage:

```shell
 .\src\FSharp.Analyzers.Cli\bin\Debug\net6.0\FSharp.Analyzers.Cli.exe --analyzers-path "C:\Users\nojaf\Projects\fantomas\.analyzerpackages\g-research.fsharp.analyzers\0.1.1\lib\net6.0" --project "C:\Users\nojaf\Projects\FSharp.Analyzers.SDK\src\FSharp.Analyzers.SDK\FSharp.Analyzers.SDK.fsproj" --exclude-analyzer "UnionCaseAnalyzer" --verbose
```

```
Info : Running in verbose mode
Info : Fail On Warnings: []
Info : Ignore Files: []
Info : Loading analyzers from C:\Users\nojaf\Projects\fantomas\.analyzerpackages\g-research.fsharp.analyzers\0.1.1\lib\net6.0
Info : Excluding UnionCaseAnalyzer from G-Research.FSharp.Analyzers, Version=0.1.1.0, Culture=neutral, PublicKeyToken=null
Info : Excluding UnionCaseAnalyzer from G-Research.FSharp.Analyzers, Version=0.1.1.0, Culture=neutral, PublicKeyToken=null
Info : Registered 4 analyzers from 1 dlls
Info : Running analyzers for C:\Users\nojaf\Projects\FSharp.Analyzers.SDK\src\FSharp.Analyzers.SDK\obj\Debug\net6.0\.NETCoreApp,Version=v6.0.AssemblyAttributes.fs
Info : Running analyzers for C:\Users\nojaf\Projects\FSharp.Analyzers.SDK\src\FSharp.Analyzers.SDK\obj\Debug\net6.0\FSharp.Analyzers.SDK.AssemblyInfo.fs
Info : Running analyzers for C:\Users\nojaf\Projects\FSharp.Analyzers.SDK\src\FSharp.Analyzers.SDK\FSharp.Analyzers.SDK.fsi
Info : Running analyzers for C:\Users\nojaf\Projects\FSharp.Analyzers.SDK\src\FSharp.Analyzers.SDK\FSharp.Analyzers.SDK.fs
Info : Running analyzers for C:\Users\nojaf\Projects\FSharp.Analyzers.SDK\src\FSharp.Analyzers.SDK\FSharp.Analyzers.SDK.Client.fsi
Info : Running analyzers for C:\Users\nojaf\Projects\FSharp.Analyzers.SDK\src\FSharp.Analyzers.SDK\FSharp.Analyzers.SDK.Client.fs

No messages found from the analyzer(s)
```

<strike>I'm currently seeing the info log twice, not sure yet why that is.</strike>
Feel free to start reviewing this.