### PR TITLE
Throw custom exception with diagnostics if the severity is Error

### DIFF
--- a/src/FSharp.Analyzers.SDK.Testing/FSharp.Analyzers.SDK.Testing.fs
+++ b/src/FSharp.Analyzers.SDK.Testing/FSharp.Analyzers.SDK.Testing.fs
@@ -38,7 +38,7 @@ type Package =
 
     override x.ToString() = $"{x.Name}_{x.Version}"
 
-exception DiagnosticErrors of FSharpDiagnostic array
+exception CompilerDiagnosticErrors of FSharpDiagnostic array
 
 let fsharpFiles = set [| ".fs"; ".fsi"; ".fsx" |]
 
@@ -254,7 +254,7 @@ let getContext (opts: FSharpProjectOptions) source =
             |> Array.filter (fun d -> d.Severity = FSharpDiagnosticSeverity.Error)
 
         if not (Array.isEmpty diagErrors) then
-            raise (DiagnosticErrors diagErrors)
+            raise (CompilerDiagnosticErrors diagErrors)
 
         let sourceText = SourceText.ofString source
         Utils.createContext checkProjectResults fileName sourceText (parseFileResults, checkFileResults)

--- a/src/FSharp.Analyzers.SDK.Testing/FSharp.Analyzers.SDK.Testing.fs
+++ b/src/FSharp.Analyzers.SDK.Testing/FSharp.Analyzers.SDK.Testing.fs
@@ -3,7 +3,6 @@ module FSharp.Analyzers.SDK.Testing
 // Don't warn about using NotifyFileChanged of the FCS API
 #nowarn "57"
 
-open FSharp.Compiler.Text
 open Microsoft.Build.Logging.StructuredLogger
 open CliWrap
 open System
@@ -11,6 +10,8 @@ open System.IO
 open System.Collections.Generic
 open System.Collections.ObjectModel
 open FSharp.Compiler.CodeAnalysis
+open FSharp.Compiler.Diagnostics
+open FSharp.Compiler.Text
 
 type FSharpProjectOptions with
 
@@ -36,6 +37,8 @@ type Package =
     }
 
     override x.ToString() = $"{x.Name}_{x.Version}"
+
+exception DiagnosticErrors of FSharpDiagnostic array
 
 let fsharpFiles = set [| ".fs"; ".fsi"; ".fsx" |]
 
@@ -246,6 +249,13 @@ let getContext (opts: FSharpProjectOptions) source =
 
     match Utils.typeCheckFile fcs printError opts fileName (Utils.SourceOfSource.DiscreteSource source) with
     | Some(parseFileResults, checkFileResults) ->
+        let diagErrors =
+            checkFileResults.Diagnostics
+            |> Array.filter (fun d -> d.Severity = FSharpDiagnosticSeverity.Error)
+
+        if not (Array.isEmpty diagErrors) then
+            raise (DiagnosticErrors diagErrors)
+
         let sourceText = SourceText.ofString source
         Utils.createContext checkProjectResults fileName sourceText (parseFileResults, checkFileResults)
     | None -> failwith "typechecking file failed"

--- a/src/FSharp.Analyzers.SDK.Testing/FSharp.Analyzers.SDK.Testing.fsi
+++ b/src/FSharp.Analyzers.SDK.Testing/FSharp.Analyzers.SDK.Testing.fsi
@@ -10,7 +10,7 @@ type FSharpProjectOptions with
 
 type Package = { Name: string; Version: string }
 
-exception DiagnosticErrors of FSharpDiagnostic array
+exception CompilerDiagnosticErrors of FSharpDiagnostic array
 
 /// <summary>Creates a classlib project in a temporary folder to gather the needed FSharpProjectOptions.</summary>
 /// <param name="framework">The target framework for the tested code to use. E.g. net6.0, net7.0</param>

--- a/src/FSharp.Analyzers.SDK.Testing/FSharp.Analyzers.SDK.Testing.fsi
+++ b/src/FSharp.Analyzers.SDK.Testing/FSharp.Analyzers.SDK.Testing.fsi
@@ -2,12 +2,15 @@ module FSharp.Analyzers.SDK.Testing
 
 open System.Threading.Tasks
 open FSharp.Compiler.CodeAnalysis
+open FSharp.Compiler.Diagnostics
 
 type FSharpProjectOptions with
 
     static member zero: FSharpProjectOptions
 
 type Package = { Name: string; Version: string }
+
+exception DiagnosticErrors of FSharpDiagnostic array
 
 /// <summary>Creates a classlib project in a temporary folder to gather the needed FSharpProjectOptions.</summary>
 /// <param name="framework">The target framework for the tested code to use. E.g. net6.0, net7.0</param>


### PR DESCRIPTION
Why should we do this?
It's very easy to construct tests which aren't valid F# but still produce tree structures that are passed on via the context. 
That could erroneously be processed by analyzers and give wrong test results.

Another pitfall is to use an API in the testcase, which isn't available in netstandard.
If the analyzer author writes a test for that, his analyzer could process the information from the context even though it wouldn't compile in the real world due to a missing overload in the netstandard API.

So, to make the analyzer/test author aware of errors in his testcases, we throw an exception with diagnostics of error severity.