### PR TITLE
Fix creation of changelog for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           artifacts: "**/*.nupkg"
           token: ${{ secrets.GITHUB_TOKEN }}
-          body: ${{ steps.changelog_reader.outputs.log_entry }}
+          body: ${{ steps.changelog_reader.outputs.changes }}
           prerelease: ${{ steps.changelog_reader.outputs.status == 'prereleased' }}
 
       - name: Push packages


### PR DESCRIPTION
`log_entry` was renamed to `changes`.
I hope this is the reason, why our automatic creation of changelogs for releases stopped to work.
See https://github.com/mindsers/changelog-reader-action/blob/d8f4048265c49bd76854ce1faa024467ca39bd7e/CHANGELOG.md?plain=1#L70
If the next release still doesn't work, we might need to play with the validation_level as we don't really do strict semver regarding the CHANGELOG entries.
But let's see, I think this is all we need.