### PR TITLE
Exit the commandline tool if the version of FSharp.Core cannot be loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+* [Use fixed version of FCS and FSharp.Core](https://github.com/ionide/FSharp.Analyzers.SDK/pull/127) (thanks @nojaf!)
+
 ## [0.16.0] - 2023-10-16
 
 ### Added

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="CliWrap" Version="3.6.4" />
-    <PackageVersion Include="FSharp.Core" Version="7.0.400" />
-    <PackageVersion Include="FSharp.Compiler.Service" Version="43.7.400" />
+    <PackageVersion Include="FSharp.Core" Version="[7.0.400]" />
+    <PackageVersion Include="FSharp.Compiler.Service" Version="[43.7.400]" />
     <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.1.8" PrivateAssets="all" />
     <PackageVersion Include="McMaster.NETCore.Plugins" Version="1.4.0" />
     <PackageVersion Include="Argu" Version="6.1.1" />

--- a/docs/content/Getting Started.fsx
+++ b/docs/content/Getting Started.fsx
@@ -34,6 +34,13 @@ dotnet add package FSharp.Analyzers.SDK
 paket add FSharp.Analyzers.SDK
 ```
 
+The `FSharp.Analyzers.SDK` takes a dependency on [FSharp.Compiler.Service](https://www.nuget.org/packages/FSharp.Compiler.Service/), which has a strict dependency on `FSharp.Core`.  
+It is considered a best practice to use the correct `FSharp.Core` version and not the implicit one from the SDK.
+
+```xml
+<PackageReference Update="FSharp.Core" Version="7.0.400" />
+```
+
 ## First analyzer
 
 An [Analyzer<'TContext>](../reference/fsharp-analyzers-sdk-analyzer-1.html) is a function that takes a `Context` and returns a list of `Message`.  

--- a/src/FSharp.Analyzers.Cli/Program.fs
+++ b/src/FSharp.Analyzers.Cli/Program.fs
@@ -273,7 +273,7 @@ let main argv =
                     printInfo "%s" msg
         }
 
-    AssemblyLoadContext.Default.add_Resolving (fun ctx assemblyName ->
+    AssemblyLoadContext.Default.add_Resolving (fun _ctx assemblyName ->
         if assemblyName.Name <> "FSharp.Core" then
             null
         else

--- a/src/FSharp.Analyzers.Cli/Program.fs
+++ b/src/FSharp.Analyzers.Cli/Program.fs
@@ -56,15 +56,9 @@ let printInfo (fmt: Printf.TextWriterFormat<'a>) : 'a =
     else
         unbox (mkKn typeof<'a>)
 
-let printError (text: Printf.TextWriterFormat<('a -> unit)>) (arg: 'a) : unit =
+let printError (text: string) : unit =
     Console.ForegroundColor <- ConsoleColor.Red
-    printf "Error : "
-    printfn text arg
-    Console.ForegroundColor <- origForegroundColor
-
-let printError2 (text: string) : unit =
-    Console.ForegroundColor <- ConsoleColor.Red
-    printf "Error : "
+    Console.Write "Error : "
     Console.WriteLine(text)
     Console.ForegroundColor <- origForegroundColor
 
@@ -96,12 +90,7 @@ let runProject (client: Client<CliAnalyzerAttribute, CliContext>) toolsPath proj
                 let fileContent = File.ReadAllText fileName
                 let sourceText = SourceText.ofString fileContent
 
-                Utils.typeCheckFile
-                    fcs
-                    (fun s -> printError "%s" s)
-                    option
-                    fileName
-                    (Utils.SourceOfSource.SourceText sourceText)
+                Utils.typeCheckFile fcs printError option fileName (Utils.SourceOfSource.SourceText sourceText)
                 |> Option.map (Utils.createContext checkProjectResults fileName sourceText)
             )
             |> Array.map (fun ctx ->
@@ -277,7 +266,7 @@ let main argv =
 
     let logger =
         { new Logger with
-            member _.Error msg = printError "%s" msg
+            member _.Error msg = printError msg
 
             member _.Verbose msg =
                 if verbose then
@@ -292,9 +281,9 @@ Consider adding <PackageReference Update="FSharp.Core" Version="<CorrectVersion>
 The correct version can be found over at https://www.nuget.org/packages/FSharp.Analyzers.SDK#dependencies-body-tab.
 """
 
-            printError2 msg
+            printError msg
         else
-            printError2 $"Could not load %s{assemblyName.Name} %A{assemblyName.Version}."
+            printError $"Could not load %s{assemblyName.Name} %A{assemblyName.Version}."
 
         exit 1
     )
@@ -318,7 +307,6 @@ The correct version can be found over at https://www.nuget.org/packages/FSharp.A
             | Some [] ->
                 printError
                     "No project given. Use `--project PATH_TO_FSPROJ`. Pass path relative to current directory.%s"
-                    ""
 
                 None
             | Some projects ->

--- a/src/FSharp.Analyzers.Cli/Program.fs
+++ b/src/FSharp.Analyzers.Cli/Program.fs
@@ -274,17 +274,17 @@ let main argv =
         }
 
     AssemblyLoadContext.Default.add_Resolving (fun ctx assemblyName ->
-        if assemblyName.Name = "FSharp.Core" then
-            let msg =
-                $"""Could not load FSharp.Core %A{assemblyName.Version}. The expected assembly version of FSharp.Core is %A{Utils.currentFSharpCoreVersion}.
-Consider adding <PackageReference Update="FSharp.Core" Version="<CorrectVersion>" /> to your .fsproj.
-The correct version can be found over at https://www.nuget.org/packages/FSharp.Analyzers.SDK#dependencies-body-tab.
-"""
-
-            printError msg
+        if assemblyName.Name <> "FSharp.Core" then
+            null
         else
-            printError $"Could not load %s{assemblyName.Name} %A{assemblyName.Version}."
 
+        let msg =
+            $"""Could not load FSharp.Core %A{assemblyName.Version}. The expected assembly version of FSharp.Core is %A{Utils.currentFSharpCoreVersion}.
+        Consider adding <PackageReference Update="FSharp.Core" Version="<CorrectVersion>" /> to your .fsproj.
+        The correct version can be found over at https://www.nuget.org/packages/FSharp.Analyzers.SDK#dependencies-body-tab.
+        """
+
+        printError msg
         exit 1
     )
 

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fs
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fs
@@ -180,6 +180,15 @@ module Utils =
     let currentFSharpAnalyzersSDKVersion =
         Assembly.GetExecutingAssembly().GetName().Version
 
+    let currentFSharpCoreVersion =
+        let currentAssembly = Assembly.GetExecutingAssembly()
+        let references = currentAssembly.GetReferencedAssemblies()
+        let fc = references |> Array.tryFind (fun ra -> ra.Name = "FSharp.Core")
+
+        match fc with
+        | None -> failwith "FSharp.Core could not be found as a reference assembly of the SDK."
+        | Some fc -> fc.Version
+
     let createContext
         (checkProjectResults: FSharpCheckProjectResults)
         (fileName: string)

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsi
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsi
@@ -161,6 +161,7 @@ module Utils =
         | SourceText of ISourceText
 
     val currentFSharpAnalyzersSDKVersion: Version
+    val currentFSharpCoreVersion: Version
 
     val createFCS: documentSource: option<string -> Async<option<ISourceText>>> -> FSharpChecker
 


### PR DESCRIPTION
Helps in https://github.com/ionide/FSharp.Analyzers.SDK/issues/124

I think it currently is a bit of a lie that we say:
![image](https://github.com/ionide/FSharp.Analyzers.SDK/assets/2621499/868d9791-abbf-4e78-ae65-d348641ee50b)

While FCS has:
![image](https://github.com/ionide/FSharp.Analyzers.SDK/assets/2621499/30a84b85-c61c-40ff-a613-a64591b1449c)

I'm in favour of locking both FCS and FSharp.Core down.