### PR TITLE
Accept direct fsc arguments as input.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.17.0] - 2023-10-26
 
 ### Changed
 * [Use fixed version of FCS and FSharp.Core](https://github.com/ionide/FSharp.Analyzers.SDK/pull/127) (thanks @nojaf!)
 * [Allow to specify multiple analyzers-paths](https://github.com/ionide/FSharp.Analyzers.SDK/pull/128) (thanks @nojaf!)
+
+### Added
+* [Accept direct fsc arguments as input](https://github.com/ionide/FSharp.Analyzers.SDK/pull/129) (thanks @nojaf!)
 
 ## [0.16.0] - 2023-10-16
 


### PR DESCRIPTION
The use-case for this is:

```
  <Target Name="Analyzer"
          DependsOnTargets="Restore;ResolveAssemblyReferencesDesignTime;ResolveProjectReferencesDesignTime;ResolvePackageDependenciesDesignTime;FindReferenceAssembliesForReferences;_GenerateCompileDependencyCache;_ComputeNonExistentFileProperty;BeforeBuild;BeforeCompile;CoreCompile">
    <PropertyGroup>
      <AnalyzersPath>&quot;$(PkgNojaf_Chad_Analyzers)\analyzers\dotnet\fs&quot;</AnalyzersPath>
    </PropertyGroup>
    <Exec Command="dotnet tool restore" />
    <Exec Command="dotnet fsharp-analyzers --fsc-args &quot;@(FscCommandLineArgs)&quot; --analyzers-path $(AnalyzersPath) --verbose --report $(MSBuildProjectDirectory)\analysis.sarif" />
  </Target>
```

We will add more end-user / getting starting documentation shortly.