### PR TITLE
check --project arguments if file exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+* [--project value should be tested if path exists](https://github.com/ionide/FSharp.Analyzers.SDK/issues/141) (thanks @dawedawe!)
+
 ## [0.19.0] - 2023-11-08
 
 ### Changed


### PR DESCRIPTION
fixes #141 

This PR also removes the doubled transformation to an absolute path.

Instead of continuing with other valid projects paths, this PR takes the decision to fail completely if at least one bad path was given. 
My thinking is that the message about the invalid path could be overseen by the users. Meaning the analyzers are effectively running for just a subset of the solution while the user thinks all of the projects are analyzed. That could mean the user misses critical analyzer results for projects that weren't analyzed because of a bad path.
