### PR TITLE
Add code-root flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * [Properly walk SynModuleSigDecl.Val](https://github.com/ionide/FSharp.Analyzers.SDK/pull/156) (thanks @nojaf!)
 * [Sarif file should not report absolute file paths](https://github.com/ionide/FSharp.Analyzers.SDK/issues/154) (thanks @nojaf!)
 
+### Added
+* [Add code-root flag](https://github.com/ionide/FSharp.Analyzers.SDK/pull/157) (thanks @nojaf!)
+
 ## [0.19.0] - 2023-11-08
 
 ### Changed

--- a/src/FSharp.Analyzers.Cli/Program.fs
+++ b/src/FSharp.Analyzers.Cli/Program.fs
@@ -43,7 +43,7 @@ type Arguments =
             | Verbose -> "Verbose logging."
             | FSC_Args _ -> "Pass in the raw fsc compiler arguments. Cannot be combined with the `--project` flag."
             | Code_Root _ ->
-                "Root of the current code repository, used in sarif report to the relative file path. The current working directory is used by default."
+                "Root of the current code repository, used in the sarif report to construct the relative file path. The current working directory is used by default."
 
 type SeverityMappings =
     {

--- a/src/FSharp.Analyzers.Cli/Program.fs
+++ b/src/FSharp.Analyzers.Cli/Program.fs
@@ -21,6 +21,7 @@ type Arguments =
     | [<Unique>] Exclude_Analyzer of string list
     | [<Unique>] Report of string
     | [<Unique>] FSC_Args of string
+    | [<Unique>] Code_Root of string
     | [<Unique>] Verbose
 
     interface IArgParserTemplate with
@@ -41,6 +42,8 @@ type Arguments =
             | Report _ -> "Write the result messages to a (sarif) report file."
             | Verbose -> "Verbose logging."
             | FSC_Args _ -> "Pass in the raw fsc compiler arguments. Cannot be combined with the `--project` flag."
+            | Code_Root _ ->
+                "Root of the current code repository, used in sarif report to the relative file path. The current working directory is used by default."
 
 type SeverityMappings =
     {
@@ -253,9 +256,12 @@ let printMessages (msgs: AnalyzerMessage list) =
 
     ()
 
-let writeReport (results: AnalyzerMessage list option) (report: string) =
+let writeReport (results: AnalyzerMessage list option) (codeRoot: string option) (report: string) =
     try
-        let pwd = Directory.GetCurrentDirectory() |> Uri
+        let codeRoot =
+            match codeRoot with
+            | None -> Directory.GetCurrentDirectory() |> Uri
+            | Some root -> Path.GetFullPath root |> Uri
 
         // Construct full path to ensure path separators are normalized.
         let report = Path.GetFullPath report
@@ -317,7 +323,7 @@ let writeReport (results: AnalyzerMessage list option) (report: string) =
 
             physicalLocation.ArtifactLocation <-
                 let al = ArtifactLocation()
-                al.Uri <- pwd.MakeRelativeUri(Uri(analyzerResult.Message.Range.FileName))
+                al.Uri <- codeRoot.MakeRelativeUri(Uri(analyzerResult.Message.Range.FileName))
                 al
 
             physicalLocation.Region <-
@@ -441,6 +447,7 @@ let main argv =
     let projOpts = results.GetResults <@ Project @> |> List.concat
     let fscArgs = results.TryGetResult <@ FSC_Args @>
     let report = results.TryGetResult <@ Report @>
+    let codeRoot = results.TryGetResult <@ Code_Root @>
 
     let results =
         if analyzers = 0 then
@@ -470,6 +477,6 @@ let main argv =
                 |> Some
 
     results |> Option.iter printMessages
-    report |> Option.iter (writeReport results)
+    report |> Option.iter (writeReport results codeRoot)
 
     calculateExitCode results


### PR DESCRIPTION
A follow-up of https://github.com/ionide/FSharp.Analyzers.SDK/pull/155.

This helps when you can execute `dotnet fsharp-analyzers` inside the `repo-root/src/Project` directory but want to report all the file paths relative to `repo-root`.