### PR TITLE
Raise clear error if empty FSC arguments were passed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+* [Raise clear error if empty FSC arguments were passed](https://github.com/ionide/FSharp.Analyzers.SDK/pull/162) (thanks @nojaf!)
+
 ## [0.20.1] - 2023-11-14
 
 ### Fixed

--- a/src/FSharp.Analyzers.Cli/Program.fs
+++ b/src/FSharp.Analyzers.Cli/Program.fs
@@ -202,6 +202,11 @@ let runFscArgs
     (globs: Glob list)
     (mappings: SeverityMappings)
     =
+    if String.IsNullOrWhiteSpace fscArgs then
+        printError "Empty --fsc-args were passed!"
+        exit 1
+    else
+
     let fscArgs = fscArgs.Split(';', StringSplitOptions.RemoveEmptyEntries)
 
     let sourceFiles =


### PR DESCRIPTION
When the design time build failed for some reason, you don't want to try and load empty arguments.