### PR TITLE
Remove AnalyzeFSharpProjectUsingFscArgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.20.2]
 
 ### Fixed
 * [Raise clear error if empty FSC arguments were passed](https://github.com/ionide/FSharp.Analyzers.SDK/pull/162) (thanks @nojaf!)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.20.2]
+## [0.20.2] - 2023-11-14
 
 ### Fixed
 * [Raise clear error if empty FSC arguments were passed](https://github.com/ionide/FSharp.Analyzers.SDK/pull/162) (thanks @nojaf!)

--- a/docs/content/Getting Started Using.md
+++ b/docs/content/Getting Started Using.md
@@ -44,11 +44,11 @@ Luckily, we can use an MSBuild custom target to take care of the path constructi
 Add [FSharp.Analyzers.Build](https://www.nuget.org/packages/FSharp.Analyzers.Build) to your `fsproj`:
 
 ```xml
-<PackageReference Include="FSharp.Analyzers.Build" Version="0.1.0" PrivateAssets="all" />
+<PackageReference Include="FSharp.Analyzers.Build" Version="0.2.0" PrivateAssets="all" />
 ```
 
-This imports two targets to your project file: `AnalyzeFSharpProject` and `AnalyzeFSharpProjectUsingFscArgs`.  
-These will allow us to easily run the analyzers for our project.  
+This imports a new target to your project file: `AnalyzeFSharpProject`.  
+And will allow us to easily run the analyzers for our project.  
 
 Before we can run `dotnet msbuild /t:AnalyzeFSharpProject`, we need to specify our settings in a property called `FSharpAnalyzersOtherFlags`:
 
@@ -69,17 +69,6 @@ dotnet msbuild /t:AnalyzeFSharpProject
 ```
 
 Note: if your project has multiple `TargetFrameworks` the tool will be invoked for each target framework.
-
-### Analyze FSharp project using FscArgs
-
-So 🤔, what is the difference between `AnalyzeFSharpProject` and `AnalyzeFSharpProjectUsingFscArgs`?
-
-The way the analyzers work is that we will programmatically type-check a project and process the results with our analyzers. In order to do this programmatically we need to construct the [FSharpProjectOptions](https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-codeanalysis-fsharpprojectoptions.html).  
-This is essentially a type that represents all the fsharp compiler arguments. When using `--project`, we will use [ProjInfo](https://github.com/ionide/proj-info) to invoke a set of MSBuild targets in the project to perform a design-time build.  
-A design-time build is basically an empty invocation of a build. It won't produce assemblies but will have constructed the correct arguments to theoretically invoke the compiler.  
-
-There's an alternative way to do this. Instead of using the `--project` argument, it's possible to use the `--fsc-args` argument to let the CLI tool construct the needed `FSharpProjectOptions`.  
-The `AnalyzeFSharpProjectUsingFscArgs` uses MSBuild to construct the raw `fsc` arguments. This can potentially be faster (due to MSBuild caching) and more accurate.
 
 ## Using analyzers in a solution
 
@@ -124,11 +113,6 @@ Add the following custom target to the [Directory.Solution.targets](https://lear
     </ItemGroup>
 
     <Target Name="AnalyzeSolution">
-        <!-- 
-        If you use `AnalyzeFSharpProjectUsingFscArgs`, it is recommended to build the solution upfront.
-        You can use the `Exec` tag to achieve this.
-        <Exec Command="dotnet build -c Release $(SolutionFileName)" />
-        -->
         <MSBuild Projects="@(ProjectsToAnalyze)" Targets="AnalyzeFSharpProject" />
     </Target>
 </Project>

--- a/src/FSharp.Analyzers.Build/CHANGELOG.md
+++ b/src/FSharp.Analyzers.Build/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This is the changelog for the `FSharp.Analyzers.Build` package specifically. It's distinct from that of the overall libraries and command-line tool.
 
+## 0.2.0 - 2023-11-15
+
+### Removed
+
+### Fixed
+* Add additional properties to trigger design time build.
+
 ## 0.1.0 - 2023-11-15
 
 ### Added

--- a/src/FSharp.Analyzers.Build/CHANGELOG.md
+++ b/src/FSharp.Analyzers.Build/CHANGELOG.md
@@ -5,6 +5,7 @@ This is the changelog for the `FSharp.Analyzers.Build` package specifically. It'
 ## 0.2.0 - 2023-11-15
 
 ### Removed
+* [Remove AnalyzeFSharpProjectUsingFscArgs](https://github.com/ionide/FSharp.Analyzers.SDK/pull/164).
 
 ### Fixed
 * Add additional properties to trigger design time build.

--- a/src/FSharp.Analyzers.Build/build/FSharp.Analyzers.Build.targets
+++ b/src/FSharp.Analyzers.Build/build/FSharp.Analyzers.Build.targets
@@ -8,27 +8,4 @@
     </Target>
 
     <Target Name="AnalyzeFSharpProject" DependsOnTargets="_AnalyzeFSharpProject" />
-
-    <Target Name="_SetDesignTimePropertiesForFSharpAnalyzers" BeforeTargets="Restore">
-        <PropertyGroup>
-            <DesignTimeBuild>true</DesignTimeBuild>
-            <ProvideCommandLineArgs>true</ProvideCommandLineArgs>
-            <SkipCompilerExecution>true</SkipCompilerExecution>
-        </PropertyGroup>
-    </Target>
-    
-    <Target
-            Name="_AnalyzeFSharpProjectUsingFscArgs"
-            DependsOnTargets="_SetDesignTimePropertiesForFSharpAnalyzers;Restore;ResolveAssemblyReferencesDesignTime;ResolveProjectReferencesDesignTime;ResolvePackageDependenciesDesignTime;FindReferenceAssembliesForReferences;_GenerateCompileDependencyCache;_ComputeNonExistentFileProperty;BeforeBuild;BeforeCompile;CoreCompile">
-
-        <Error Condition="$(FSharpAnalyzersOtherFlags) == ''" Text="A property FSharpAnalyzersOtherFlags should exists with all the analyzer cli arguments!" />
-        <Message Importance="low" Text="FSC arguments: @(FscCommandLineArgs)"/>
-        <Message Importance="High" Text="Analyzing $(MSBuildProjectFile)"/>
-        <Exec
-                ContinueOnError="true"
-                IgnoreExitCode="true"
-                Command="dotnet fsharp-analyzers --fsc-args &quot;@(FscCommandLineArgs)&quot; $(FSharpAnalyzersOtherFlags)" />
-    </Target>
-    
-    <Target Name="AnalyzeFSharpProjectUsingFscArgs" DependsOnTargets="_AnalyzeFSharpProjectUsingFscArgs" />
 </Project>

--- a/src/FSharp.Analyzers.Build/buildMultitargeting/FSharp.Analyzers.Build.targets
+++ b/src/FSharp.Analyzers.Build/buildMultitargeting/FSharp.Analyzers.Build.targets
@@ -13,18 +13,4 @@
                  Targets="_AnalyzeFSharpProject"
                  BuildInParallel="true"/>
     </Target>
-
-    <Target Name="AnalyzeFSharpProjectUsingFscArgs">
-        <!-- TFMs but no TF -> multitarget, analyzing for each TFM -->
-        <ItemGroup>
-            <_TFMItems Include="$(TargetFrameworks)"/>
-            <_SingleTfmAnalysis Include="$(MSBuildProjectFullPath)"
-                                AdditionalProperties="TargetFramework=%(_TFMItems.Identity);"
-                                UndefineProperties="TargetFrameworks"/>
-        </ItemGroup>
-        <MSBuild Projects="@(_SingleTfmAnalysis)"
-                 Targets="_AnalyzeFSharpProjectUsingFscArgs"
-                 Properties="DesignTimeBuild=True;ProvideCommandLineArgs=True;SkipCompilerExecution=True"
-                 BuildInParallel="true"/>
-    </Target>
 </Project>


### PR DESCRIPTION
Alas, I must shatter my dream of reusing the `fsc` arguments provided by MSBuild.
I noticed some drawbacks when doing a `DesignTimeBuild` for projects that have project references.

Let us take `Fantomas.Client.fsproj` and `Fantomas.Client.Tests.fsproj` as example:

- Performing the design time build for `Fantomas.Client.Tests.fsproj` will trigger a build for `Fantomas.Client.fsproj` as well. However, this won't produce a binary for `Fantomas.Client`, while `Fantomas.Client.Tests` does depend on its existence from the fsc args perspective.
- Because `Fantomas.Client.Tests` already built `Fantomas.Client` (without producing a binary), `CoreCompile` will be skipped when we try and do the design time build for `Fantomas.Core` and thus `FscCommandLineArgs` will not be populated. I believe this to be a larger problem in the `FSharpTargets` but I digress.

So in short, the idea of reusing `FscCommandLineArgs` from MSBuild only works when:
- All dependent projects did produce a binary.
- `CoreCompile` of the current project is not skipped.

Initially, we did a full build of `fantomas.sln` before invoking the targets, which helps with the dependent projects having binaries. But doesn't help that `CoreCompile` is being skipped.

I don't see a scenario where we can have the best of both worlds, so I recommend we stick to `AnalyzeFSharpProject` and keep using `proj-info` to crack the projects.

That being said, I do still see a use-case for `--fsc-args` as cli parameter input. This can be great for debugging and exploring.