### PR TITLE
Wrap the path to the binlog in quotes when building a test project

### DIFF
--- a/src/FSharp.Analyzers.SDK.Testing/FSharp.Analyzers.SDK.Testing.fs
+++ b/src/FSharp.Analyzers.SDK.Testing/FSharp.Analyzers.SDK.Testing.fs
@@ -165,7 +165,7 @@ let createProject (binLogPath: string) (tmpProjectDir: string) (framework: strin
                     .Wrap("dotnet")
                     .WithEnvironmentVariables(roDic)
                     .WithWorkingDirectory(tmpProjectDir)
-                    .WithArguments($"build -bl:{binLogPath}")
+                    .WithArguments($"build -bl:\"{binLogPath}\"")
                     .WithStandardOutputPipe(PipeTarget.ToStringBuilder(stdOutBuffer))
                     .WithStandardErrorPipe(PipeTarget.ToStringBuilder(stdErrBuffer))
                     .WithValidation(CommandResultValidation.ZeroExitCode)


### PR DESCRIPTION
I was having a go at building the SDK locally to test some things, and the build script failed to run the tests with errors like
```
MSBuild version 17.8.3+195e7f5a3 for .NET
MSBUILD : error MSB1009: Project file does not exist.
Switch: Webb\AppData\Local\Temp\FSharp.Analyzers.SDK.BinLogCache\v0.21.0.0_net7.0_Newtonsoft.Json_13.0.3_Fantomas.FCS_6.2.0.binlog

StdErr:

Exception:
CliWrap.Exceptions.CommandExecutionException: Command execution failed because the underlying process (dotnet.exe#12396) returned a non-zero exit code (1).

Command:
dotnet build -bl:C:\Users\Richard Webb\AppData\Local\Temp\FSharp.Analyzers.SDK.BinLogCache\v0.21.0.0_net7.0_Newtonsoft.Json_13.0.3_Fantomas.FCS_6.2.0.binlog
```

As it happens, the path to my user/temp directory has a space in it, and the ```Switch: Webb\AppData\Local\``` made it look like it wasn't coping with that.

This change appears to be enough to get the command line build to complete.