### PR TITLE
Add a description to the Cli tool nuget package

### DIFF
--- a/src/FSharp.Analyzers.Cli/FSharp.Analyzers.Cli.fsproj
+++ b/src/FSharp.Analyzers.Cli/FSharp.Analyzers.Cli.fsproj
@@ -9,6 +9,7 @@
     <PackAsTool>true</PackAsTool>
     <PackageId>fsharp-analyzers</PackageId>
     <ToolCommandName>fsharp-analyzers</ToolCommandName>
+    <Description>A dotnet CLI tool for running F# analyzers</Description>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Quite trivial and i'm not sure what the text should be, it's just that whenever I look at listings on nuget.org that don't have a description set, the default 'Package Description' text sticks out to me - e.g.

![image](https://github.com/ionide/FSharp.Analyzers.SDK/assets/1178570/8e681d32-59d4-499c-9328-51317d13d918)
