### PR TITLE
Remove the condition on setting PackageLicenseExpression/PackageTags in directory.build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,7 +28,7 @@
     <PackageReference Include="Ionide.KeepAChangelog.Tasks" PrivateAssets="All" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(IsPackable)' == 'true'">
+  <PropertyGroup>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>F#;analyzers;compiler;tooling;editor;</PackageTags>
   </PropertyGroup>


### PR DESCRIPTION
refs https://github.com/ionide/FSharp.Analyzers.SDK/issues/33 where the license seems to not be getting applied to the packages due to the condition.

Alternatively the suggestion in https://github.com/ionide/FSharp.Analyzers.SDK/issues/33#issuecomment-1823079531 to move the logix into a directory.build.targets also seems to work, so I can do whichever one is prefered.