### PR TITLE
always emit TailCalls to not overflow the stack

### DIFF
--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsproj
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsproj
@@ -7,6 +7,7 @@
     <Authors>Krzysztof Cieslak</Authors>
     <Description>SDK for building custom analyzers for FSAC / F# editors</Description>
     <Copyright>Copyright 2019 Lambda Factory</Copyright>
+    <Tailcalls>true</Tailcalls>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ASTCollecting.fsi" />


### PR DESCRIPTION
With this, we can use the debug build on some more complex code bases like fsharp itself.