### PR TITLE
Log a warning if the path it's trying to load analyzers from doesn't …

### DIFF
--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.Client.fs
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.Client.fs
@@ -219,6 +219,7 @@ type Client<'TAttribute, 'TContext when 'TAttribute :> AnalyzerAttribute and 'TC
 
             Array.length analyzers, analyzers |> Seq.collect snd |> Seq.length
         else
+            logger.LogWarning("Analyzer path {analyzerPath} does not exist", dir)
             0, 0
 
     member x.RunAnalyzers(ctx: 'TContext) : Async<AnalyzerMessage list> =


### PR DESCRIPTION
…exist

Just a thought in case anyone else thinks it's helpful - 

If you run the cli tool and specify a project that doesn't exist then you get a warning logged, but if the analyzers-path doesn't exist then you get no output with default logging, and in detailed mode get a note about trying to load analyzers followed by ```Registered 0 analyzers from 0 dlls``` but no actual error or anything - so,  I just thought it might be useful if there was an actual warning in that case.