### PR TITLE
Add a package description to FSharp.Analyzers.Build

### DIFF
--- a/src/FSharp.Analyzers.Build/FSharp.Analyzers.Build.csproj
+++ b/src/FSharp.Analyzers.Build/FSharp.Analyzers.Build.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netstandard1.0</TargetFramework>
         <NoPackageAnalysis>true</NoPackageAnalysis>
@@ -7,6 +7,7 @@
         <DevelopmentDependency>true</DevelopmentDependency>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <ChangelogFile>$(MSBuildThisFileDirectory)CHANGELOG.md</ChangelogFile>
+        <Description>MSBuild integration for fsharp-analyzers</Description>
     </PropertyGroup>
     <ItemGroup>
         <Content Include="build\*" PackagePath="build\" />


### PR DESCRIPTION
As #172 except for FSharp.Analyzers.Build:

refs the current default description field:

![image](https://github.com/ionide/FSharp.Analyzers.SDK/assets/1178570/5a4fbac0-7d83-4175-b4be-058f45012bc6)
