### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/src/FSharp.Analyzers.Build/CHANGELOG.md
+++ b/src/FSharp.Analyzers.Build/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This is the changelog for the `FSharp.Analyzers.Build` package specifically. It's distinct from that of the overall libraries and command-line tool.
 
+## 0.3.0 - 2024-01-05
+
+### Changed
+* Update target framework to netstandard2.0. [#193](https://github.com/ionide/FSharp.Analyzers.SDK/pull/193)
+
 ## 0.2.0 - 2023-11-15
 
 ### Removed


### PR DESCRIPTION
Merging this one in won't publish the package just yet.
But we probably want to have it published when we ship the next SDK version.