### PR TITLE
Fail the tool when analyzers fail to load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+* [Fail the tool when any analyzers fail to load](https://github.com/ionide/FSharp.Analyzers.SDK/pull/198) (thanks @Smaug123!)
+
 ## [0.23.0] - 2024-01-05
 
 ### Changed

--- a/src/FSharp.Analyzers.SDK.Testing/FSharp.Analyzers.SDK.Testing.fs
+++ b/src/FSharp.Analyzers.SDK.Testing/FSharp.Analyzers.SDK.Testing.fs
@@ -224,15 +224,18 @@ let getContextFor (opts: FSharpProjectOptions) isSignature source =
     let fcs = Utils.createFCS (Some documentSource)
     let pathToAnalyzerDlls = Path.GetFullPath(".")
 
-    let foundDlls, registeredAnalyzers =
+    let assemblyLoadStats =
         let client = Client<CliAnalyzerAttribute, CliContext>()
         client.LoadAnalyzers pathToAnalyzerDlls
 
-    if foundDlls = 0 then
+    if assemblyLoadStats.AnalyzerAssemblies = 0 then
         failwith $"no Dlls found in {pathToAnalyzerDlls}"
 
-    if registeredAnalyzers = 0 then
+    if assemblyLoadStats.Analyzers = 0 then
         failwith $"no Analyzers found in {pathToAnalyzerDlls}"
+
+    if assemblyLoadStats.FailedAssemblies > 0 then
+        failwith $"failed to load %i{assemblyLoadStats.FailedAssemblies} Analyzers in {pathToAnalyzerDlls}"
 
     let opts =
         { opts with

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.Client.fsi
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.Client.fsi
@@ -8,6 +8,16 @@ type AnalysisResult =
         Output: Result<Message list, exn>
     }
 
+type AssemblyLoadStats =
+    {
+        /// The number of DLLs from which we tried to load analyzers.
+        AnalyzerAssemblies: int
+        /// The total number of analyzers loaded across all attempted DLLs.
+        Analyzers: int
+        /// The number of assemblies from which we tried and failed to load any DLLs.
+        FailedAssemblies: int
+    }
+
 type ExcludeInclude =
     /// A predicate function to exclude Analyzers.
     | ExcludeFilter of (string -> bool)
@@ -23,7 +33,7 @@ type Client<'TAttribute, 'TContext when 'TAttribute :> AnalyzerAttribute and 'TC
     /// Analyzers are filtered according to the ExcludeInclude set, if provided.
     /// </summary>
     /// <returns>number of found dlls matching `*Analyzer*.dll` and number of registered analyzers</returns>
-    member LoadAnalyzers: dir: string * ?excludeInclude: ExcludeInclude -> int * int
+    member LoadAnalyzers: dir: string * ?excludeInclude: ExcludeInclude -> AssemblyLoadStats
     /// <summary>Runs all registered analyzers for given context (file).</summary>
     /// <returns>list of messages. Ignores errors from the analyzers</returns>
     member RunAnalyzers: ctx: 'TContext -> Async<AnalyzerMessage list>


### PR DESCRIPTION
The tool currently silently swallows this sort of error.

This change is backward incompatible. Is that OK?