### PR TITLE
Add RequireQualifiedAccess to Severity type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
 ### Changed
+* [Add `RequireQualifiedAccess` to `Severity` type](https://github.com/ionide/FSharp.Analyzers.SDK/pull/199) (thanks @Smaug123!)
 * [Fail the tool when any analyzers fail to load](https://github.com/ionide/FSharp.Analyzers.SDK/pull/198) (thanks @Smaug123!)
 
 ## [0.23.0] - 2024-01-05

--- a/docs/content/Dual Analyzer.fsx
+++ b/docs/content/Dual Analyzer.fsx
@@ -87,7 +87,7 @@ let private topologicallySortedOpenStatementsAnalyzer
                     Type = "Unsorted System open statement"
                     Message = $"%s{openStatementText} was found after non System namespaces where opened!"
                     Code = "SOT001"
-                    Severity = Warning
+                    Severity = Severity.Warning
                     Range = mOpen
                     Fixes = []
                 }

--- a/docs/content/Getting Started Writing.fsx
+++ b/docs/content/Getting Started Writing.fsx
@@ -79,7 +79,7 @@ let optionValueAnalyzer: Analyzer<CliContext> =
                         Type = "Option.Value analyzer"
                         Message = "Option.Value shouldn't be used"
                         Code = "OV001"
-                        Severity = Warning
+                        Severity = Severity.Warning
                         Range = FSharp.Compiler.Text.Range.Zero
                         Fixes = []
                     }

--- a/samples/OptionAnalyzer/Library.fs
+++ b/samples/OptionAnalyzer/Library.fs
@@ -36,7 +36,7 @@ let optionValueAnalyzer: Analyzer<CliContext> =
                         Type = "Option.Value analyzer"
                         Message = "Option.Value shouldn't be used"
                         Code = "OV001"
-                        Severity = Warning
+                        Severity = Severity.Warning
                         Range = r
                         Fixes = []
                     }

--- a/src/FSharp.Analyzers.Cli/Program.fs
+++ b/src/FSharp.Analyzers.Cli/Program.fs
@@ -84,13 +84,13 @@ type SeverityMappings =
 let mapMessageToSeverity (mappings: SeverityMappings) (msg: FSharp.Analyzers.SDK.AnalyzerMessage) =
     let targetSeverity =
         if mappings.TreatAsInfo |> Set.contains msg.Message.Code then
-            Info
+            Severity.Info
         else if mappings.TreatAsHint |> Set.contains msg.Message.Code then
-            Hint
+            Severity.Hint
         else if mappings.TreatAsWarning |> Set.contains msg.Message.Code then
-            Warning
+            Severity.Warning
         else if mappings.TreatAsError |> Set.contains msg.Message.Code then
-            Error
+            Severity.Error
         else
             msg.Message.Severity
 
@@ -247,10 +247,10 @@ let printMessages (msgs: AnalyzerMessage list) =
     let severityToLogLevel =
         Map.ofArray
             [|
-                Error, LogLevel.Error
-                Warning, LogLevel.Warning
-                Info, LogLevel.Information
-                Hint, LogLevel.Trace
+                Severity.Error, LogLevel.Error
+                Severity.Warning, LogLevel.Warning
+                Severity.Info, LogLevel.Information
+                Severity.Hint, LogLevel.Trace
             |]
 
     if List.isEmpty msgs then
@@ -276,7 +276,7 @@ let printMessages (msgs: AnalyzerMessage list) =
             m.Range.FileName,
             m.Range.StartLine,
             m.Range.StartColumn,
-            (m.Severity.ToString()),
+            m.Severity.ToString(),
             m.Code,
             m.Message
         )
@@ -338,10 +338,10 @@ let writeReport (results: AnalyzerMessage list option) (codeRoot: string option)
 
             result.Level <-
                 match analyzerResult.Message.Severity with
-                | Info -> FailureLevel.Note
-                | Hint -> FailureLevel.Note
-                | Warning -> FailureLevel.Warning
-                | Error -> FailureLevel.Error
+                | Severity.Info -> FailureLevel.Note
+                | Severity.Hint -> FailureLevel.Note
+                | Severity.Warning -> FailureLevel.Warning
+                | Severity.Error -> FailureLevel.Error
 
             let msg = Message()
             msg.Text <- analyzerResult.Message.Message
@@ -384,7 +384,7 @@ let calculateExitCode (msgs: AnalyzerMessage list option) : int =
             |> List.exists (fun analyzerMessage ->
                 let message = analyzerMessage.Message
 
-                message.Severity = Error
+                message.Severity = Severity.Error
             )
 
         if check then -2 else 0

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fs
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fs
@@ -148,6 +148,7 @@ type Fix =
         ToText: string
     }
 
+[<RequireQualifiedAccess>]
 type Severity =
     | Info
     | Hint

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsi
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsi
@@ -119,6 +119,7 @@ type Fix =
         ToText: string
     }
 
+[<RequireQualifiedAccess>]
 type Severity =
     | Info
     | Hint


### PR DESCRIPTION
We currently export the DU case `Error`, which clashes with FSharp.Core's `Result.Error`. This change means we never conflict with FSharp.Core. The change is source-incompatible, so it will require a release note.