### PR TITLE
Fail the tool if any analysis fails

### DIFF
--- a/src/FSharp.Analyzers.Cli/FSharp.Analyzers.Cli.fsproj
+++ b/src/FSharp.Analyzers.Cli/FSharp.Analyzers.Cli.fsproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <Compile Include="CustomLogging.fs" />
+    <Compile Include="Result.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/src/FSharp.Analyzers.Cli/Program.fs
+++ b/src/FSharp.Analyzers.Cli/Program.fs
@@ -171,12 +171,11 @@ let runProjectAux
             |> Async.Parallel
 
         return
-            Some
-                [
-                    for messages in messagesPerAnalyzer do
-                        let mappedMessages = messages |> List.map (mapMessageToSeverity mappings)
-                        yield! mappedMessages
-                ]
+            [
+                for messages in messagesPerAnalyzer do
+                    let mappedMessages = messages |> List.map (mapMessageToSeverity mappings)
+                    yield! mappedMessages
+            ]
     }
 
 let runProject
@@ -623,6 +622,7 @@ let main argv =
             | [], Some fscArgs ->
                 runFscArgs client fscArgs exclInclFiles severityMapping
                 |> Async.RunSynchronously
+                |> Some
             | projects, None ->
                 for projPath in projects do
                     if not (File.Exists(projPath)) then
@@ -635,7 +635,6 @@ let main argv =
                 )
                 |> Async.Sequential
                 |> Async.RunSynchronously
-                |> Array.choose id
                 |> List.concat
                 |> Some
 

--- a/src/FSharp.Analyzers.Cli/Result.fs
+++ b/src/FSharp.Analyzers.Cli/Result.fs
@@ -1,0 +1,15 @@
+module FSharp.Analyzers.Cli.Result
+
+let allOkOrError<'ok, 'err> (results: Result<'ok, 'err> list) : Result<'ok list, 'ok list * 'err list> =
+    let oks, errs =
+        (([], []), results)
+        ||> List.fold (fun (oks, errs) result ->
+            match result with
+            | Ok ok -> ok :: oks, errs
+            | Error err -> oks, err :: errs
+        )
+
+    let oks = List.rev oks
+    let errs = List.rev errs
+
+    if List.isEmpty errs then Ok oks else Error(oks, errs)

--- a/src/FSharp.Analyzers.SDK.Testing/FSharp.Analyzers.SDK.Testing.fs
+++ b/src/FSharp.Analyzers.SDK.Testing/FSharp.Analyzers.SDK.Testing.fs
@@ -257,7 +257,7 @@ let getContextFor (opts: FSharpProjectOptions) isSignature source =
             fileName
             (Utils.SourceOfSource.DiscreteSource source)
     with
-    | Some(parseFileResults, checkFileResults) ->
+    | Ok(parseFileResults, checkFileResults) ->
         let diagErrors =
             checkFileResults.Diagnostics
             |> Array.filter (fun d -> d.Severity = FSharpDiagnosticSeverity.Error)
@@ -267,7 +267,7 @@ let getContextFor (opts: FSharpProjectOptions) isSignature source =
 
         let sourceText = SourceText.ofString source
         Utils.createContext checkProjectResults fileName sourceText (parseFileResults, checkFileResults)
-    | None -> failwith "typechecking file failed"
+    | Error e -> failwith $"typechecking file failed: %O{e}"
 
 let getContext (opts: FSharpProjectOptions) source = getContextFor opts false source
 let getContextForSignature (opts: FSharpProjectOptions) source = getContextFor opts true source

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fs
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fs
@@ -176,6 +176,8 @@ type AnalyzerMessage =
         HelpUri: string option
     }
 
+type AnalysisFailure = | Aborted
+
 module Utils =
     let currentFSharpAnalyzersSDKVersion =
         Assembly.GetExecutingAssembly().GetName().Version
@@ -230,6 +232,7 @@ module Utils =
         (options: FSharpProjectOptions)
         (fileName: string)
         (source: SourceOfSource)
+        : Result<FSharpParseFileResults * FSharpCheckFileResults, AnalysisFailure>
         =
 
         let sourceText =
@@ -247,5 +250,5 @@ module Utils =
         match checkAnswer with
         | FSharpCheckFileAnswer.Aborted ->
             logger.LogError("Checking of file {0} aborted", fileName)
-            None
-        | FSharpCheckFileAnswer.Succeeded result -> Some(parseRes, result)
+            Error AnalysisFailure.Aborted
+        | FSharpCheckFileAnswer.Succeeded result -> Ok(parseRes, result)

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsi
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsi
@@ -152,6 +152,12 @@ type AnalyzerMessage =
         HelpUri: string option
     }
 
+/// Represents a failure to run FSC analysis.
+[<RequireQualifiedAccess>]
+type AnalysisFailure =
+    /// The F# compiler service aborted during analysis.
+    | Aborted
+
 module Utils =
 
     [<RequireQualifiedAccess>]
@@ -171,7 +177,7 @@ module Utils =
         options: FSharpProjectOptions ->
         fileName: string ->
         source: SourceOfSource ->
-            option<FSharpParseFileResults * FSharpCheckFileResults>
+            Result<FSharpParseFileResults * FSharpCheckFileResults, AnalysisFailure>
 
     val createContext:
         checkProjectResults: FSharpCheckProjectResults ->


### PR DESCRIPTION
Motivation is https://github.com/Smaug123/fsharp-prattparser/actions/runs/7619221208/job/20751901249 , which succeeded despite the output being as follows:

```
info: Running in verbose mode
info: Treat as Hints: []
info: Treat as Info: []
info: Treat as Warning: []
info: Treat as Error: [GRA-IMMUTABLECOLLECTIONEQUALITY-001, GRA-INTERPOLATED-001, GRA-JSONOPTS-001, GRA-LOGARGFUNCFULLAPP-001, GRA-STRING-001, GRA-STRING-002, GRA-STRING-003, GRA-TYPE-ANNOTATE-001, GRA-UNIONCASE-001, GRA-VIRTUALCALL-001]
info: Exclude Files: []
info: Include Files: []
info: Loading analyzers from /home/runner/work/fsharp-prattparser/fsharp-prattparser/.analyzerpackages/g-research.fsharp.analyzers/0.7.0/
info: Registered 12 analyzers from 1 dlls
error: Checking of file /home/runner/work/fsharp-prattparser/fsharp-prattparser/PrattParser/obj/Debug/net8.0/.NETCoreApp,Version=v8.0.AssemblyAttributes.fs aborted
error: Checking of file /home/runner/work/fsharp-prattparser/fsharp-prattparser/PrattParser/obj/Debug/net8.0/PrattParser.AssemblyInfo.fs aborted
error: Checking of file /home/runner/work/fsharp-prattparser/fsharp-prattparser/PrattParser/obj/Debug/net8.0/PrattParser.Version.fs aborted
error: Checking of file /home/runner/work/fsharp-prattparser/fsharp-prattparser/PrattParser/Parser.fs aborted
info: No messages found from the analyzer(s)
```

In order not to have a heap of primitive types like `_ list option`, I pulled out the failure case into a single-case DU. That way, the semantics are much clearer if you're only looking at the type signatures.