### PR TITLE
Fail on no analyzers registered

### DIFF
--- a/src/FSharp.Analyzers.Cli/Program.fs
+++ b/src/FSharp.Analyzers.Cli/Program.fs
@@ -605,7 +605,7 @@ let main argv =
 
     let results =
         if analyzers = 0 then
-            Some []
+            None
         else
             match projOpts, fscArgs with
             | [], None ->


### PR DESCRIPTION
(I seem to be hitting every possible way to hold this tool wrongly!)

I think it's more useful to fail when there are no analyzers registered, than to return "OK, did nothing". I suspect it's going to be *very* unusual to intentionally register no analyzers.