### PR TITLE
Error when analyzer globs go unmatched

### DIFF
--- a/src/FSharp.Analyzers.Cli/Properties/launchSettings.json
+++ b/src/FSharp.Analyzers.Cli/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "ReadMeSample": {
       "commandName": "Project",
-      "commandLineArgs": "--include-analyzers OptionAnailyzer --project /Users/patrick/Documents/GitHub/FSharp.Analyzers.SDK/samples/OptionAnalyzer/OptionAnalyzer.fsproj --analyzers-path /Users/patrick/Documents/GitHub/FSharp.Analyzers.SDK/samples/OptionAnalyzer/bin/Release --verbosity d"
+      "commandLineArgs": "--project ./samples/OptionAnalyzer/OptionAnalyzer.fsproj --analyzers-path ./samples/OptionAnalyzer/bin/Release --verbosity d"
     }
   }
 }

--- a/src/FSharp.Analyzers.Cli/Properties/launchSettings.json
+++ b/src/FSharp.Analyzers.Cli/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "ReadMeSample": {
       "commandName": "Project",
-      "commandLineArgs": "--project ./samples/OptionAnalyzer/OptionAnalyzer.fsproj --analyzers-path ./samples/OptionAnalyzer/bin/Release --verbosity d"
+      "commandLineArgs": "--include-analyzers OptionAnailyzer --project /Users/patrick/Documents/GitHub/FSharp.Analyzers.SDK/samples/OptionAnalyzer/OptionAnalyzer.fsproj --analyzers-path /Users/patrick/Documents/GitHub/FSharp.Analyzers.SDK/samples/OptionAnalyzer/bin/Release --verbosity d"
     }
   }
 }


### PR DESCRIPTION
This is a perf hit, of course, but I claim it's not an important one.

I took the liberty of unindenting the code at the end of the main function (by early-`exit`ing), but this has made the diff pretty nasty, sorry :( 

Fixes #203.

I could understand not wanting this; on balance, though, I think these cases are more likely to be user error than intended.