### PR TITLE
bump FCS and FSC to 8.0.200 now that they've been released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+* [Update to FCS and FSharp.Core 43.8.200](https://github.com/ionide/FSharp.Analyzers.SDK/pull/207)
+
 ## [0.24.0] - 2024-01-30
 
 ### Changed

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="CliWrap" Version="3.6.4" />
-    <PackageVersion Include="FSharp.Core" Version="[8.0.100]" />
-    <PackageVersion Include="FSharp.Compiler.Service" Version="[43.8.100]" />
+    <PackageVersion Include="FSharp.Core" Version="[8.0.200]" />
+    <PackageVersion Include="FSharp.Compiler.Service" Version="[43.8.200]" />
     <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.1.8" PrivateAssets="all" />
     <PackageVersion Include="McMaster.NETCore.Plugins" Version="1.4.0" />
     <PackageVersion Include="Argu" Version="6.1.1" />


### PR DESCRIPTION
This is required to get FSAC updated because of the explicit-match constraint from this repo.