### PR TITLE
When printing analysis messages to the console, separate the texttual…

### DIFF
--- a/src/FSharp.Analyzers.Cli/Program.fs
+++ b/src/FSharp.Analyzers.Cli/Program.fs
@@ -281,7 +281,7 @@ let printMessages (msgs: AnalyzerMessage list) =
 
         msgLogger.Log(
             severityToLogLevel[m.Severity],
-            "{0}({1},{2}): {3} {4} - {5}",
+            "{0}({1},{2}): {3} {4} : {5}",
             m.Range.FileName,
             m.Range.StartLine,
             m.Range.StartColumn,


### PR DESCRIPTION
… description from the rest with a ':' instead of '-'

Context: 
I've been trying to get the analyzer results integrated into a CI build at work, which is running in Azure DevOps.

I've got the SARIF results file being consumed by the MS SAST scans tab DevOps extension, and that appears to be working nicely.
However, I though it might be nice if the results could be displayed as regular build warnings as well as in the sarif, so they just display in the main build output instead of you having to look at a different tab to see issues.

I couldn't get the results to show up as warnings, but then noticed that the analysers CLI tool currently outputs the results to the console with the final field separated from the rest with a ```-``` rather than the usual ```:``` and it does seem that changing that causes the output to be recognised as warnings (complete with yellow text output rather than white).

Is this a reasonable change to make?

