### PR TITLE
Reset the console foreground colour with control codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+* [Reset the console foreground colour after printing results](https://github.com/ionide/FSharp.Analyzers.SDK/pull/216) (thanks @Numpsy!)
+
 ## [0.26.0] - 2024-05-15
 
 ### Changed

--- a/src/FSharp.Analyzers.Cli/CustomLogging.fs
+++ b/src/FSharp.Analyzers.Cli/CustomLogging.fs
@@ -34,7 +34,7 @@ type CustomFormatter(options: IOptionsMonitor<CustomOptions>) as this =
         if formatterOptions.UseAnalyzersMsgStyle then
             this.SetColor(textWriter, logEntry.LogLevel)
             textWriter.WriteLine(message)
-            this.ResetColor()
+            this.ResetColor(textWriter)
         else
             this.WritePrefix(textWriter, logEntry.LogLevel)
             textWriter.WriteLine(message)
@@ -72,7 +72,9 @@ type CustomFormatter(options: IOptionsMonitor<CustomOptions>) as this =
 
         textWriter.Write(color)
 
-    member private _.ResetColor() = Console.ForegroundColor <- origColor
+    member private _.ResetColor(textWriter: TextWriter) =
+        textWriter.Write("\x1B[0m")
+        Console.ForegroundColor <- origColor
 
     interface IDisposable with
         member _.Dispose() = optionsReloadToken.Dispose()


### PR DESCRIPTION
refs #215 

Printing the 0m control code looks like how Fargo resets the colour, and that seems to work for me here on Windows (cmd.exe and windows terminal).
I haven't tested it on any other OS yet, and not sure if there is a need to reset Console.ForegroundColor as well as printing the codes.