### PR TITLE
Update Microsoft.Extensions.Logging.Console to 6.0.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.4" PrivateAssets="All" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="6.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="MSBuild.StructuredLogger" Version="2.2.240" />
     <PackageVersion Include="NUnit" Version="3.13.3" />


### PR DESCRIPTION
When I was doing https://github.com/G-Research/fsharp-analyzers/pull/85 I got a security warning from Visual Studio about a transitive dependency

FSharp.Analyzers.SDK.Testing -> Microsoft.Extensions.Logging.Console -> System.Text.Json 6.0.0

Because System.Text.Json 6.0.0 has known CVEs.

So I wondered if it would be useful to update Microsoft.Extensions.Logging.Console to 6.0.1, which has removed the NuGet dependency on System.Text.Json in the .NET 6.0 TFM so it just uses the in-box version.

This shouldn't effect the version of Microsoft.Extensions.Logging.Abstractions used by the SDK lib itself, just the console lib used by the Testing and Cli packages.
