### PR TITLE
Prevent File Locking Issue

### DIFF
--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.Client.fs
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.Client.fs
@@ -169,6 +169,7 @@ type Client<'TAttribute, 'TContext when 'TAttribute :> AnalyzerAttribute and 'TC
                                 fun config ->
                                     config.DefaultContext <- AssemblyLoadContext.Default
                                     config.PreferSharedTypes <- true
+                                    config.LoadInMemory <- true
                             )
 
                         Some(analyzerDll, analyzerLoader.LoadDefaultAssembly())


### PR DESCRIPTION
## Problem

In VSCode I currently have the following settings to enable analyzers in the IDE.

```json
{
    "FSharp.enableAnalyzers": true,
    "FSharp.analyzersPath": [
        "packages/Analyzers"
    ],
}
```

When switching between branches of my codebase, if there are different versions of my analyzers, I will get an error during the paket restore step due to the files being used. My current workaround is to manually delete the folder listed above and then restore my solution.

## Proposed Solution

In order to circumvent this, there appears to be a setting in the package we are consuming to allow loading the assemblies into memory. Looking through the code, it does not appear we are using this setting nor is it overriding any hot reload functionality.

[CreateFromAssemblyFile](https://github.com/natemcmaster/DotNetCorePlugins/blob/a6094157bfd1ace9d6b13df108c488526cfe850f/src/Plugins/PluginLoader.cs#L143-L153)

[PluginConfig constructor](https://github.com/natemcmaster/DotNetCorePlugins/blob/a6094157bfd1ace9d6b13df108c488526cfe850f/src/Plugins/PluginConfig.cs#L21-L34)
