### PR TITLE
Add GitHub logging output format

### DIFF
--- a/docs/content/Running during CI.md
+++ b/docs/content/Running during CI.md
@@ -42,6 +42,7 @@ Example when using MSBuild:
 
 ## GitHub Actions
 
+### GitHub Advanced Security
 If you are using [GitHub Actions](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/sarif-output) you can easily send the *sarif file* to [CodeQL](https://codeql.github.com/).
 
 ```yml
@@ -67,5 +68,15 @@ Sample:
 ![Example](https://user-images.githubusercontent.com/2621499/275484611-e38461f8-3689-4bf0-8ab8-11a6318e01aa.png)
 
 See [fsproject/fantomas#2962](https://github.com/fsprojects/fantomas/pull/2962) for more information.
+
+### Github Workflow Commands
+If you cannot use GitHub Advanced Security (e.g. if your repository is private), you can get similar annotations by running the analyzers with `--output-format github`.
+This will make the analyzers print their results as [GitHub Workflow Commands](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions).
+If you for instance have a GitHub Action to run analyzers on every pull request, these annotations will show up in the "Files changed" on the pull request.
+If the annotations don't show correctly, you might need to set the `code-root` to the root of the repository.
+
+Note that GitHub has a hard limit of 10 annotations of each type (notice, warning, error) per CI step.
+This means that only the first 10 errors, the first 10 warnings and the first 10 hints/info results from analyzers will generate annotations.
+The workflow log will contain all analyzer results even if a job hits the annotation limits.
 
 [Previous]({{fsdocs-previous-page-link}})


### PR DESCRIPTION
This adds a new CLI parameter, `--output-format`, which can be set to either `default` or `github`.
The `default` option preserves the current way to print analyzer results to stdout.

The `github` option instead prints the analyzer results in a format that can be understood as a code annotation by GitHub Actions ([reference](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions)).
This feature allows users without a GitHub Advanced Security subscription to get nicely formatted analyzer results in CI for private repositories.

Here are some (lightly censored) screenshots of what it looks like in a real code base.

In the "Files changed" section of a pull request:
<img width="1391" alt="Screenshot 2025-03-21 at 12 35 52" src="https://github.com/user-attachments/assets/90e1ef52-74de-47ff-8900-a9bffa0167c0" />

In the workflow log view:
<img width="1038" alt="Screenshot 2025-03-21 at 12 37 04" src="https://github.com/user-attachments/assets/e955d7f8-84c0-4220-8d5f-bc0966724ab7" />

The main limitation of this is that GitHub has a hard limit of 10 annotations per PR. But for organizations that keep their number of warnings low, most PRs should not introduce more than 10 new analyzer warnings.
Also, GitHub annotations only have three severity levels, so I've mapped both `Hint` and `Info` into the `::notice` level.

Closes #229.
