### PR TITLE
[RFC] Update McMaster.NETCore.Plugins to v2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="FSharp.Core" Version="[9.0.201]" />
     <PackageVersion Include="FSharp.Compiler.Service" Version="[43.9.201]" />
     <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.1.8" PrivateAssets="all" />
-    <PackageVersion Include="McMaster.NETCore.Plugins" Version="1.4.0" />
+    <PackageVersion Include="McMaster.NETCore.Plugins" Version="2.0.0" />
     <PackageVersion Include="Argu" Version="6.1.1" />
     <PackageVersion Include="Glob" Version="1.1.9" />
     <PackageVersion Include="Ionide.ProjInfo.ProjectSystem" Version="0.68.0" />


### PR DESCRIPTION
Just a thought when looking at other stuff - the new version requires .NET 8 at a minimum but has also removed the dependencies on ```Microsoft.DotNet.PlatformAbstractions``` and ```Microsoft.Extensions.DependencyModel``` which seemed like it might be a nice change (PlatformAbstractions being not updated any more).
I tried building fsautocomplete against an SDK build with the change and it built ok, but I'm not sure if there's anything else in the stack that could be negatively effected?