### PR TITLE
Add project options to analyzer contexts

### DIFF
--- a/src/FSharp.Analyzers.Cli/Program.fs
+++ b/src/FSharp.Analyzers.Cli/Program.fs
@@ -173,6 +173,7 @@ let runProject
     async {
         logger.LogInformation("Checking project {0}", fsharpOptions.ProjectFileName)
         let! checkProjectResults = fcs.ParseAndCheckProject(fsharpOptions)
+        let analyzerOptions = BackgroundCompilerOptions fsharpOptions
 
         let! messagesPerAnalyzer =
             fsharpOptions.SourceFiles
@@ -202,7 +203,7 @@ let runProject
                     let! parseAndCheckResults = fcs.GetBackgroundCheckResultsForFileInProject(fileName, fsharpOptions)
 
                     let ctx =
-                        Utils.createContext checkProjectResults fileName sourceText parseAndCheckResults
+                        Utils.createContext checkProjectResults fileName sourceText parseAndCheckResults analyzerOptions
 
                     logger.LogInformation("Running analyzers for {0}", ctx.FileName)
                     let! results = client.RunAnalyzers ctx

--- a/src/FSharp.Analyzers.SDK.Testing/FSharp.Analyzers.SDK.Testing.fs
+++ b/src/FSharp.Analyzers.SDK.Testing/FSharp.Analyzers.SDK.Testing.fs
@@ -245,6 +245,7 @@ let getContextFor (opts: FSharpProjectOptions) isSignature source =
     fcs.NotifyFileChanged(fileName, opts) |> Async.RunSynchronously // workaround for https://github.com/dotnet/fsharp/issues/15960
     let checkProjectResults = fcs.ParseAndCheckProject(opts) |> Async.RunSynchronously
     let allSymbolUses = checkProjectResults.GetAllUsesOfAllSymbols()
+    let analyzerOpts = BackgroundCompilerOptions opts
 
     if Array.isEmpty allSymbolUses then
         failwith "no symboluses"
@@ -266,7 +267,7 @@ let getContextFor (opts: FSharpProjectOptions) isSignature source =
             raise (CompilerDiagnosticErrors diagErrors)
 
         let sourceText = SourceText.ofString source
-        Utils.createContext checkProjectResults fileName sourceText (parseFileResults, checkFileResults)
+        Utils.createContext checkProjectResults fileName sourceText (parseFileResults, checkFileResults) analyzerOpts
     | Error e -> failwith $"typechecking file failed: %O{e}"
 
 let getContext (opts: FSharpProjectOptions) source = getContextFor opts false source

--- a/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsi
+++ b/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsi
@@ -47,6 +47,24 @@ type EditorAnalyzerAttribute =
 /// Marker interface which both the CliContext and EditorContext implement
 type Context = interface end
 
+/// Options related to the project being analyzed.
+type AnalyzerProjectOptions =
+    | BackgroundCompilerOptions of FSharpProjectOptions
+    | TransparentCompilerOptions of FSharpProjectSnapshot
+    
+    /// The current project name.
+    member ProjectFileName: string
+    /// The identifier of the current project.
+    member ProjectId: string option
+    /// The set of source files in the current project.
+    member SourceFiles: string list
+    /// Projects referenced by this project.
+    member ReferencedProjectsPath: string list
+    /// The time at which the project was loaded.
+    member LoadTime: DateTime
+    /// Additional command line argument options for the project.
+    member OtherOptions: string list
+
 /// All the relevant compiler information for a given file.
 /// Contains the source text, untyped and typed tree information.
 type CliContext =
@@ -69,6 +87,8 @@ type CliContext =
         /// A handle to the results of the entire project
         /// See <a href="https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-codeanalysis-fsharpcheckprojectresults.html">FSharpCheckProjectResults Type</a>
         CheckProjectResults: FSharpCheckProjectResults
+        /// Options related to the project being analyzed.
+        ProjectOptions: AnalyzerProjectOptions
     }
 
     interface Context
@@ -101,6 +121,8 @@ type EditorContext =
         /// A handle to the results of the entire project
         /// See <a href="https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-codeanalysis-fsharpcheckprojectresults.html">FSharpCheckProjectResults Type</a>
         CheckProjectResults: FSharpCheckProjectResults option
+        // Options related to the project being analyzed.
+        ProjectOptions: AnalyzerProjectOptions
     }
 
     interface Context
@@ -184,4 +206,5 @@ module Utils =
         fileName: string ->
         sourceText: ISourceText ->
         parseFileResults: FSharpParseFileResults * checkFileResults: FSharpCheckFileResults ->
+        projectOptions: AnalyzerProjectOptions ->
             CliContext


### PR DESCRIPTION
refs https://github.com/ionide/ionide-analyzers/issues/147

Based in discussions in https://github.com/ionide/ionide-analyzers/issues/147, where there are currently issues due to ```FSharpProjectOptions``` not being accessible in Ionide when the transparent compiler is enabled