### PR TITLE
Move membersToIgnore/exprTypesToIgnore out of visitDeclaration()

### DIFF
--- a/src/FSharp.Analyzers.SDK/TASTCollecting.fs
+++ b/src/FSharp.Analyzers.SDK/TASTCollecting.fs
@@ -356,11 +356,12 @@ module TASTCollecting =
 
     and visitObjMember f memb = visitExpr f memb.Body
 
-    let rec visitDeclaration f d =
-        let membersToIgnore = set [ "CompareTo"; "GetHashCode"; "Equals" ]
+    let membersToIgnore = set [ "CompareTo"; "GetHashCode"; "Equals" ]
 
-        let exprTypesToIgnore =
+    let exprTypesToIgnore =
             set [ "Microsoft.FSharp.Core.int"; "Microsoft.FSharp.Core.bool" ]
+
+    let rec visitDeclaration f d =
 
         match d with
         | FSharpImplementationFileDeclaration.Entity(_e, subDecls) ->


### PR DESCRIPTION
Just a thought when playing with things - looks like creating these sets inside ```visitDeclaration``` creates a substantial number of lists and sets, and as the contents are constant it doesn't seem like it should need to create them more than once?

Running a memory profile of the SDK cli tool against one of my projects got this before:

<img width="1192" height="258" alt="image" src="https://github.com/user-attachments/assets/157689f2-6d8a-41bc-82b6-f2e12bf4fa0c" />

and this after:

<img width="1187" height="284" alt="image" src="https://github.com/user-attachments/assets/44df1d10-863d-4914-b984-414641aa51bd" />
