### PR TITLE
Update the getting started link in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can also set up a run configuration of FSharp.Analyzers.Cli in your favorite
 
 ## Using Analyzers
 
-Checkout our [Getting Started](https://ionide.io/FSharp.Analyzers.SDK/content/Getting%20Started%20Using.html) guide for analyzer users!
+Checkout our [Getting Started](https://ionide.io/FSharp.Analyzers.SDK/content/getting-started/Installing%20Analyzers.html) guide for analyzer users!
 
 ## Writing Analyzers
 


### PR DESCRIPTION
The current link gets a 404 error, so this updates it to the same link in the docs at https://ionide.io/FSharp.Analyzers.SDK/#Using-Analyzers