### PR TITLE
Utilize Fsc args in msbuild analyze if available

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -6,7 +6,15 @@
       "version": "20.0.0",
       "commands": [
         "fsdocs"
-      ]
+      ],
+      "rollForward": false
+    },
+    "fsharp-analyzers": {
+      "version": "0.32.0",
+      "commands": [
+        "fsharp-analyzers"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -6,15 +6,7 @@
       "version": "20.0.0",
       "commands": [
         "fsdocs"
-      ],
-      "rollForward": false
-    },
-    "fsharp-analyzers": {
-      "version": "0.32.0",
-      "commands": [
-        "fsharp-analyzers"
-      ],
-      "rollForward": false
+      ]
     }
   }
 }

--- a/docs/content/getting-started/MSBuild.md
+++ b/docs/content/getting-started/MSBuild.md
@@ -197,7 +197,7 @@ Run `dotnet msbuild YourProject.fsproj /t:Dump` and verify that `CodeRoot` has a
 
 ## Analyze FSharp Projects After Build
 
-If you'd like the analyzer to be ran after a build, you can set `RunAnalyzersDuringBuild` or `RunAnalyzers` to `true` in your project file:
+If you'd like the analyzer to be run after a `dotnet build`, you can set `RunAnalyzersDuringBuild` or `RunAnalyzers` to `true` in your project file:
 
 ```xml
 <PropertyGroup>

--- a/docs/content/getting-started/MSBuild.md
+++ b/docs/content/getting-started/MSBuild.md
@@ -195,4 +195,30 @@ We often add a dummy target to a project to print out some values:
 
 Run `dotnet msbuild YourProject.fsproj /t:Dump` and verify that `CodeRoot` has a value or not.
 
+## Analyze FSharp Projects After Build
+
+If you'd like the analyzer to be ran after a build, you can set `RunAnalyzersDuringBuild` or `RunAnalyzers` to `true` in your project file:
+
+```xml
+<PropertyGroup>
+    <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
+    <FSharpAnalyzersOtherFlags>similar to previous section</FSharpAnalyzersOtherFlags>
+</PropertyGroup>
+```
+
+This is reusing the [Roslyn Analyzers variables](https://learn.microsoft.com/en-us/visualstudio/code-quality/disable-code-analysis?view=vs-2022#net-framework-projects-1). For brevity, here are the relevant variables:
+
+- `RunAnalyzersDuringBuild` : Controls whether analyzers run at build time.
+- `RunAnalyzers` : It takes precedence over `RunAnalyzersDuringBuild` and is used to control whether analyzers run at build time or not.
+
+This will run after the `CoreCompile` [target](https://github.com/dotnet/fsharp/blob/dd929579fc275ab99fd496da34bbe6bdade73c86/src/FSharp.Build/Microsoft.FSharp.Targets#L279-L280), which is the default target for building F# projects. The benefit of running after the `CoreCompile` target is this will speed up the analyzers execution as it will attempt to re-use the F# Compiler command line args `FscCommandLineArgs` property to run the analyzers without requiring a [design-time build](https://github.com/dotnet/project-system/blob/main/docs/design-time-builds.md). 
+
+However, this target might be skipped if the project is not built again due to [incremental builds](https://learn.microsoft.com/en-us/visualstudio/msbuild/incremental-builds?view=vs-2022). If you want to run the analyzers after every build, you can set `FSharpAnalyzers_AlwaysRunAfterBuild` to `true`:
+
+```xml
+<PropertyGroup>
+    <FSharpAnalyzers_AlwaysRunAfterBuild>true</FSharpAnalyzers_AlwaysRunAfterBuild>
+</PropertyGroup>
+```
+
 [Next]({{fsdocs-next-page-link}})

--- a/docs/content/getting-started/MSBuild.md
+++ b/docs/content/getting-started/MSBuild.md
@@ -213,11 +213,11 @@ This is reusing the [Roslyn Analyzers variables](https://learn.microsoft.com/en-
 
 This will run after the `CoreCompile` [target](https://github.com/dotnet/fsharp/blob/dd929579fc275ab99fd496da34bbe6bdade73c86/src/FSharp.Build/Microsoft.FSharp.Targets#L279-L280), which is the default target for building F# projects. The benefit of running after the `CoreCompile` target is this will speed up the analyzers execution as it will attempt to re-use the F# Compiler command line args `FscCommandLineArgs` property to run the analyzers without requiring a [design-time build](https://github.com/dotnet/project-system/blob/main/docs/design-time-builds.md). 
 
-However, the `FSharpAnalyzerAfterBuild` target might be skipped if the `CoreCompile` target is not run due to [incremental builds](https://learn.microsoft.com/en-us/visualstudio/msbuild/incremental-builds?view=vs-2022). If you want to run the analyzers after every build, you can set `FSharpAnalyzers_AlwaysRunAfterBuild` to `true`: 
+However, the `FSharpAnalyzerAfterBuild` target might be skipped if the `CoreCompile` target is not run due to [incremental builds](https://learn.microsoft.com/en-us/visualstudio/msbuild/incremental-builds?view=vs-2022). If you want to run the analyzers after every build, you can set `FSharpAnalyzersAlwaysRunAfterBuild` to `true`: 
 
 ```xml
 <PropertyGroup>
-    <FSharpAnalyzers_AlwaysRunAfterBuild>true</FSharpAnalyzers_AlwaysRunAfterBuild>
+    <FSharpAnalyzersAlwaysRunAfterBuild>true</FSharpAnalyzersAlwaysRunAfterBuild>
 </PropertyGroup>
 ```
 

--- a/docs/content/getting-started/MSBuild.md
+++ b/docs/content/getting-started/MSBuild.md
@@ -221,4 +221,15 @@ However, the `FSharpAnalyzerAfterBuild` target might be skipped if the `CoreComp
 </PropertyGroup>
 ```
 
+### Treating Warnings as Errors
+
+You can use the standard [WarningsAsErrors](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/errors-warnings#warningsaserrors-and-warningsnotaserrors) MSBuild property to treat specific warnings as errors. For example, to treat all warnings from the `OptionAnalyzer` (OV001) as errors, you can add the following to your project file:
+
+```xml
+<PropertyGroup>
+    <WarningsAsErrors>OV001</WarningsAsErrors>
+</PropertyGroup>
+```
+
+
 [Next]({{fsdocs-next-page-link}})

--- a/docs/content/getting-started/MSBuild.md
+++ b/docs/content/getting-started/MSBuild.md
@@ -213,7 +213,7 @@ This is reusing the [Roslyn Analyzers variables](https://learn.microsoft.com/en-
 
 This will run after the `CoreCompile` [target](https://github.com/dotnet/fsharp/blob/dd929579fc275ab99fd496da34bbe6bdade73c86/src/FSharp.Build/Microsoft.FSharp.Targets#L279-L280), which is the default target for building F# projects. The benefit of running after the `CoreCompile` target is this will speed up the analyzers execution as it will attempt to re-use the F# Compiler command line args `FscCommandLineArgs` property to run the analyzers without requiring a [design-time build](https://github.com/dotnet/project-system/blob/main/docs/design-time-builds.md). 
 
-However, this target might be skipped if the project is not built again due to [incremental builds](https://learn.microsoft.com/en-us/visualstudio/msbuild/incremental-builds?view=vs-2022). If you want to run the analyzers after every build, you can set `FSharpAnalyzers_AlwaysRunAfterBuild` to `true`:
+However, the `FSharpAnalyzerAfterBuild` target might be skipped if the `CoreCompile` target is not run due to [incremental builds](https://learn.microsoft.com/en-us/visualstudio/msbuild/incremental-builds?view=vs-2022). If you want to run the analyzers after every build, you can set `FSharpAnalyzers_AlwaysRunAfterBuild` to `true`: 
 
 ```xml
 <PropertyGroup>

--- a/samples/MsBuildExample/MsBuildExample.fsproj
+++ b/samples/MsBuildExample/MsBuildExample.fsproj
@@ -4,7 +4,7 @@
 
   
 <PropertyGroup>
-    <RunAnalyzers>true</RunAnalyzers>
+    <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
     <FSharpAnalyzersOtherFlags>--analyzers-path "../../artifacts/bin/OptionAnalyzer/debug" -v d</FSharpAnalyzersOtherFlags>
     <FSharpAnalyzers_Exe>../../artifacts/bin/FSharp.Analyzers.Cli/debug/FSharp.Analyzers.Cli.dll</FSharpAnalyzers_Exe>
     <!-- <FSharpAnalyzers_AlwaysRunAfterBuild>true</FSharpAnalyzers_AlwaysRunAfterBuild> -->

--- a/samples/MsBuildExample/MsBuildExample.fsproj
+++ b/samples/MsBuildExample/MsBuildExample.fsproj
@@ -10,6 +10,8 @@
     <FSharpAnalyzersExe>../../artifacts/bin/FSharp.Analyzers.Cli/debug/FSharp.Analyzers.Cli.dll</FSharpAnalyzersExe>
     <!-- Uncomment to always run the analyzer after a build, even if CoreCompile did not run -->
     <!-- <FSharpAnalyzersAlwaysRunAfterBuild>true</FSharpAnalyzersAlwaysRunAfterBuild> -->
+    <!-- Uncomment to Treat OV001 (OptionAnalyzer) warnings as errors -->
+    <!-- <WarningsAsErrors>OV001</WarningsAsErrors> -->
 </PropertyGroup>
 
   <PropertyGroup>

--- a/samples/MsBuildExample/MsBuildExample.fsproj
+++ b/samples/MsBuildExample/MsBuildExample.fsproj
@@ -6,11 +6,12 @@
 <PropertyGroup>
     <RunAnalyzers>true</RunAnalyzers>
     <FSharpAnalyzersOtherFlags>--analyzers-path "../../artifacts/bin/OptionAnalyzer/debug" -v d</FSharpAnalyzersOtherFlags>
+    <!-- <FSharpAnalyzers_AlwaysRunAfterBuild>true</FSharpAnalyzers_AlwaysRunAfterBuild> -->
 </PropertyGroup>
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/MsBuildExample/MsBuildExample.fsproj
+++ b/samples/MsBuildExample/MsBuildExample.fsproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\src\FSharp.Analyzers.Build\buildMultitargeting\FSharp.Analyzers.Build.targets" />
+
+  
+<PropertyGroup>
+    <RunAnalyzers>true</RunAnalyzers>
+    <FSharpAnalyzersOtherFlags>--analyzers-path "../../artifacts/bin/OptionAnalyzer/debug" -v d</FSharpAnalyzersOtherFlags>
+</PropertyGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OptionAnalyzer\OptionAnalyzer.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/MsBuildExample/MsBuildExample.fsproj
+++ b/samples/MsBuildExample/MsBuildExample.fsproj
@@ -6,8 +6,8 @@
 <PropertyGroup>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
     <FSharpAnalyzersOtherFlags>--analyzers-path "../../artifacts/bin/OptionAnalyzer/debug" -v d</FSharpAnalyzersOtherFlags>
-    <FSharpAnalyzers_Exe>../../artifacts/bin/FSharp.Analyzers.Cli/debug/FSharp.Analyzers.Cli.dll</FSharpAnalyzers_Exe>
-    <!-- <FSharpAnalyzers_AlwaysRunAfterBuild>true</FSharpAnalyzers_AlwaysRunAfterBuild> -->
+    <FSharpAnalyzersExe>../../artifacts/bin/FSharp.Analyzers.Cli/debug/FSharp.Analyzers.Cli.dll</FSharpAnalyzersExe>
+    <!-- <FSharpAnalyzersAlwaysRunAfterBuild>true</FSharpAnalyzersAlwaysRunAfterBuild> -->
 </PropertyGroup>
 
   <PropertyGroup>

--- a/samples/MsBuildExample/MsBuildExample.fsproj
+++ b/samples/MsBuildExample/MsBuildExample.fsproj
@@ -1,12 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+<Import Project="../../src/FSharp.Analyzers.Build/buildMultitargeting/FSharp.Analyzers.Build.targets" />
 
-  <Import Project="../../src/FSharp.Analyzers.Build/buildMultitargeting/FSharp.Analyzers.Build.targets" />
-
-  
 <PropertyGroup>
+    <!-- Set this to true if you'd like the analyzer to run during a build -->
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
+    <!-- Additional flags to pass to the analyzer CLI -->
     <FSharpAnalyzersOtherFlags>--analyzers-path "../../artifacts/bin/OptionAnalyzer/debug" -v d</FSharpAnalyzersOtherFlags>
+    <!-- Point to the dotnet tool or the FSharp.Analyzers.Cli.dll for debugging. -->
     <FSharpAnalyzersExe>../../artifacts/bin/FSharp.Analyzers.Cli/debug/FSharp.Analyzers.Cli.dll</FSharpAnalyzersExe>
+    <!-- Uncomment to always run the analyzer after a build, even if CoreCompile did not run -->
     <!-- <FSharpAnalyzersAlwaysRunAfterBuild>true</FSharpAnalyzersAlwaysRunAfterBuild> -->
 </PropertyGroup>
 

--- a/samples/MsBuildExample/MsBuildExample.fsproj
+++ b/samples/MsBuildExample/MsBuildExample.fsproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\src\FSharp.Analyzers.Build\buildMultitargeting\FSharp.Analyzers.Build.targets" />
+  <Import Project="../../src/FSharp.Analyzers.Build/buildMultitargeting/FSharp.Analyzers.Build.targets" />
 
   
 <PropertyGroup>
     <RunAnalyzers>true</RunAnalyzers>
     <FSharpAnalyzersOtherFlags>--analyzers-path "../../artifacts/bin/OptionAnalyzer/debug" -v d</FSharpAnalyzersOtherFlags>
+    <FSharpAnalyzers_Exe>../../artifacts/bin/FSharp.Analyzers.Cli/debug/FSharp.Analyzers.Cli.dll</FSharpAnalyzers_Exe>
     <!-- <FSharpAnalyzers_AlwaysRunAfterBuild>true</FSharpAnalyzers_AlwaysRunAfterBuild> -->
 </PropertyGroup>
 
@@ -19,7 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\OptionAnalyzer\OptionAnalyzer.fsproj" />
+    <ProjectReference Include="../OptionAnalyzer/OptionAnalyzer.fsproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="../../src/FSharp.Analyzers.Cli/FSharp.Analyzers.Cli.fsproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/samples/MsBuildExample/Program.fs
+++ b/samples/MsBuildExample/Program.fs
@@ -1,0 +1,5 @@
+﻿// For more information see https://aka.ms/fsharp-console-apps
+
+let value = Some 42
+
+printfn "The value is: %d" value.Value // This will cause a warning from the OptionAnalyzer

--- a/src/FSharp.Analyzers.Build/build/FSharp.Analyzers.Build.targets
+++ b/src/FSharp.Analyzers.Build/build/FSharp.Analyzers.Build.targets
@@ -1,8 +1,11 @@
 <Project>
 
     <PropertyGroup>
+        <!-- Used for dotnet host discovery -->
         <FSharpAnalyzers_ExeHost Condition="'$(FSharpAnalyzers_ExeHost)' == ''">dotnet</FSharpAnalyzers_ExeHost>
+        <!-- Points to the dotnet tool or the FSharp.Analyzers.Cli.dll for debugging -->
         <FSharpAnalyzers_Exe Condition="'$(FSharpAnalyzers_Exe)' == ''">fsharp-analyzers</FSharpAnalyzers_Exe>
+        <!-- The build will continue even if the analyzer fails -->
         <FSharpAnalyzers_ContinueOnError Condition="'$(FSharpAnalyzers_ContinueOnError)' == ''">true</FSharpAnalyzers_ContinueOnError>
         <_FSharpAnalyzers_ProjectOptions>--project &quot;$(MSBuildProjectFile)&quot;</_FSharpAnalyzers_ProjectOptions>
     </PropertyGroup>
@@ -35,7 +38,11 @@
         Condition="'$(RunAnalyzers)' == 'true'">
         <Error Condition="$(FSharpAnalyzersOtherFlags) == ''" Text="A property FSharpAnalyzersOtherFlags should exists with all the analyzer cli arguments!" />
         <PropertyGroup>
-            <FSharpAnalyzers_AlwaysRunAfterBuild Condition="$(FSharpAnalyzers_AlwaysRunAfterBuild) == '' and '@(FscCommandLineArgs->Count())' != '0'">true</FSharpAnalyzers_AlwaysRunAfterBuild>
+            <!-- 
+                If FscCommandLineArgs is empty, then CoreCompile did not run, we'll try to skip running the analyzer if this wasn't explicitly set to true
+            -->
+            <FSharpAnalyzers_AlwaysRunAfterBuild Condition="'$(FSharpAnalyzers_AlwaysRunAfterBuild)' == '' and '@(FscCommandLineArgs->Count())' != '0'">true</FSharpAnalyzers_AlwaysRunAfterBuild>
+            <!-- We'll try to use FscCommandLineArgs- to speed up analyzer execution since this skips requiring a design-time build -->
             <_FSharpAnalyzers_ProjectOptions Condition="'@(FscCommandLineArgs->Count())' != '0'">--fsc-args &quot;@(FscCommandLineArgs)&quot;</_FSharpAnalyzers_ProjectOptions>
         </PropertyGroup>
         <Exec

--- a/src/FSharp.Analyzers.Build/build/FSharp.Analyzers.Build.targets
+++ b/src/FSharp.Analyzers.Build/build/FSharp.Analyzers.Build.targets
@@ -1,11 +1,46 @@
 <Project>
+
+    <PropertyGroup>
+        <_AnalyzerProjectOptions>--project &quot;$(MSBuildProjectFile)&quot;</_AnalyzerProjectOptions>
+    </PropertyGroup>
+
     <Target Name="_AnalyzeFSharpProject">
         <Error Condition="$(FSharpAnalyzersOtherFlags) == ''" Text="A property FSharpAnalyzersOtherFlags should exists with all the analyzer cli arguments!" />
         <Exec
                 ContinueOnError="true"
                 IgnoreExitCode="true"
-                Command="dotnet fsharp-analyzers --project &quot;$(MSBuildProjectFile)&quot; $(FSharpAnalyzersOtherFlags)" />
+                Command="dotnet fsharp-analyzers $(_AnalyzerProjectOptions) $(FSharpAnalyzersOtherFlags)" />
     </Target>
 
     <Target Name="AnalyzeFSharpProject" DependsOnTargets="_AnalyzeFSharpProject" />
+
+    <Target Name="_SetupFSharpAnalyzerProjectOptions" BeforeTargets="CoreCompile" Condition="'$(RunAnalyzers)' == 'true'">
+        <PropertyGroup>
+            <!-- 
+                Required for F# Targets CoreCompile to output command line arguments 
+                https://github.com/dotnet/fsharp/blob/53929f2e01281a614a15033dfaae6fb6d00bb543/src/FSharp.Build/Fsc.fs#L721-L725 
+                https://github.com/dotnet/fsharp/blob/53929f2e01281a614a15033dfaae6fb6d00bb543/src/FSharp.Build/Microsoft.FSharp.Targets#L418C19-L418C32
+            -->
+            <ProvideCommandLineArgs>true</ProvideCommandLineArgs>
+        </PropertyGroup>
+    </Target>
+
+    <Target Name="FsharpAnalyzerAfterBuild" DependsOnTargets="_SetupFSharpAnalyzerProjectOptions" AfterTargets="AfterBuild" Condition="'$(RunAnalyzers)' == 'true'">
+        <Error Condition="$(FSharpAnalyzersOtherFlags) == ''" Text="A property FSharpAnalyzersOtherFlags should exists with all the analyzer cli arguments!" />
+        <!-- 
+            Question: Should we only execute this target if FscCommandLineArgs is not empty? 
+            Argument for Incremental builds may skip CoreCompile if no files changed, so we don't want to run the analyzer in that case.
+            There may be a better way to detect if CoreCompile was skipped but this seems to work.
+            And if someone wants to run the analyzer without FscCommandLineArgs, they can run the AnalyzeFSharpProject target directly.
+        -->
+        <PropertyGroup>
+            <_AnalyzerProjectOptions Condition="'@(FscCommandLineArgs->Count())' != '0'">--fsc-args &quot;@(FscCommandLineArgs)&quot;</_AnalyzerProjectOptions>
+        </PropertyGroup>
+        <Exec
+                ContinueOnError="true"
+                IgnoreExitCode="true"
+                Condition="'@(FscCommandLineArgs->Count())' != '0'"
+                Command="dotnet fsharp-analyzers $(_AnalyzerProjectOptions) $(FSharpAnalyzersOtherFlags)" />
+
+    </Target>
 </Project>

--- a/src/FSharp.Analyzers.Build/build/FSharp.Analyzers.Build.targets
+++ b/src/FSharp.Analyzers.Build/build/FSharp.Analyzers.Build.targets
@@ -1,15 +1,18 @@
 <Project>
 
     <PropertyGroup>
-        <_AnalyzerProjectOptions>--project &quot;$(MSBuildProjectFile)&quot;</_AnalyzerProjectOptions>
+        <FSharpAnalyzers_ExeHost Condition="'$(FSharpAnalyzers_ExeHost)' == ''">dotnet</FSharpAnalyzers_ExeHost>
+        <FSharpAnalyzers_Exe Condition="'$(FSharpAnalyzers_Exe)' == ''">fsharp-analyzers</FSharpAnalyzers_Exe>
+        <FSharpAnalyzers_ContinueOnError Condition="'$(FSharpAnalyzers_ContinueOnError)' == ''">true</FSharpAnalyzers_ContinueOnError>
+        <_FSharpAnalyzers_ProjectOptions>--project &quot;$(MSBuildProjectFile)&quot;</_FSharpAnalyzers_ProjectOptions>
     </PropertyGroup>
 
     <Target Name="_AnalyzeFSharpProject">
         <Error Condition="$(FSharpAnalyzersOtherFlags) == ''" Text="A property FSharpAnalyzersOtherFlags should exists with all the analyzer cli arguments!" />
         <Exec
-                ContinueOnError="true"
+                ContinueOnError="$(FSharpAnalyzers_ContinueOnError)"
                 IgnoreExitCode="true"
-                Command="dotnet fsharp-analyzers $(_AnalyzerProjectOptions) $(FSharpAnalyzersOtherFlags)" />
+                Command="$(FSharpAnalyzers_ExeHost) $(FSharpAnalyzers_Exe) $(_FSharpAnalyzers_ProjectOptions) $(FSharpAnalyzersOtherFlags)" />
     </Target>
 
     <Target Name="AnalyzeFSharpProject" DependsOnTargets="_AnalyzeFSharpProject" />
@@ -25,22 +28,21 @@
         </PropertyGroup>
     </Target>
 
-    <Target Name="FsharpAnalyzerAfterBuild" DependsOnTargets="_SetupFSharpAnalyzerProjectOptions" AfterTargets="AfterBuild" Condition="'$(RunAnalyzers)' == 'true'">
+    <Target 
+        Name="_FSharpAnalyzerAfterBuild" 
+        DependsOnTargets="_SetupFSharpAnalyzerProjectOptions;CoreCompile" 
+        AfterTargets="AfterBuild" 
+        Condition="'$(RunAnalyzers)' == 'true'">
         <Error Condition="$(FSharpAnalyzersOtherFlags) == ''" Text="A property FSharpAnalyzersOtherFlags should exists with all the analyzer cli arguments!" />
-        <!-- 
-            Question: Should we only execute this target if FscCommandLineArgs is not empty? 
-            Argument for Incremental builds may skip CoreCompile if no files changed, so we don't want to run the analyzer in that case.
-            There may be a better way to detect if CoreCompile was skipped but this seems to work.
-            And if someone wants to run the analyzer without FscCommandLineArgs, they can run the AnalyzeFSharpProject target directly.
-        -->
         <PropertyGroup>
-            <_AnalyzerProjectOptions Condition="'@(FscCommandLineArgs->Count())' != '0'">--fsc-args &quot;@(FscCommandLineArgs)&quot;</_AnalyzerProjectOptions>
+            <FSharpAnalyzers_AlwaysRunAfterBuild Condition="$(FSharpAnalyzers_AlwaysRunAfterBuild) == '' and '@(FscCommandLineArgs->Count())' != '0'">true</FSharpAnalyzers_AlwaysRunAfterBuild>
+            <_FSharpAnalyzers_ProjectOptions Condition="'@(FscCommandLineArgs->Count())' != '0'">--fsc-args &quot;@(FscCommandLineArgs)&quot;</_FSharpAnalyzers_ProjectOptions>
         </PropertyGroup>
         <Exec
-                ContinueOnError="true"
-                IgnoreExitCode="true"
-                Condition="'@(FscCommandLineArgs->Count())' != '0'"
-                Command="dotnet fsharp-analyzers $(_AnalyzerProjectOptions) $(FSharpAnalyzersOtherFlags)" />
-
+                ContinueOnError="$(FSharpAnalyzers_ContinueOnError)"
+                Condition="'$(FSharpAnalyzers_AlwaysRunAfterBuild)' == 'true'"
+                Command="$(FSharpAnalyzers_ExeHost) $(FSharpAnalyzers_Exe) $(_FSharpAnalyzers_ProjectOptions) $(FSharpAnalyzersOtherFlags)" />
     </Target>
+
+    <Target Name="FSharpAnalyzerAfterBuild" DependsOnTargets="_FSharpAnalyzerAfterBuild"/>
 </Project>

--- a/src/FSharp.Analyzers.Build/build/FSharp.Analyzers.Build.targets
+++ b/src/FSharp.Analyzers.Build/build/FSharp.Analyzers.Build.targets
@@ -20,7 +20,25 @@
 
     <Target Name="AnalyzeFSharpProject" DependsOnTargets="_AnalyzeFSharpProject" />
 
-    <Target Name="_SetupFSharpAnalyzerProjectOptions" BeforeTargets="CoreCompile" Condition="'$(RunAnalyzers)' == 'true'">
+    <Target Name="_FSharpAnalyzersDetermineRunAnalyzersValues" BeforeTargets="CoreCompile">
+        <!-- 
+            Roslyn uses multiple values for determining whether to run analyzers 
+            see: https://learn.microsoft.com/en-us/visualstudio/code-quality/disable-code-analysis?view=vs-2019#net-framework-projects-1
+
+            RunAnalyzersDuringBuild : 	Controls whether analyzers run at build time.
+            RunAnalyzers:  It takes precedence over RunAnalyzersDuringBuild
+        -->
+        <PropertyGroup>
+            <_FSharpAnalyzers_RunDuringBuild Condition="'$(RunAnalyzersDuringBuild)' != ''">$(RunAnalyzersDuringBuild)</_FSharpAnalyzers_RunDuringBuild>
+            <_FSharpAnalyzers_RunDuringBuild Condition="'$(RunAnalyzers)' != ''">$(RunAnalyzers)</_FSharpAnalyzers_RunDuringBuild>
+        </PropertyGroup>
+    </Target>
+
+    <Target 
+        Name="_SetupFSharpAnalyzerProjectOptions" 
+        DependsOnTargets="_FSharpAnalyzersDetermineRunAnalyzersValues"
+        BeforeTargets="CoreCompile" 
+        Condition="'$(_FSharpAnalyzers_RunDuringBuild)' == 'true'">
         <PropertyGroup>
             <!-- 
                 Required for F# Targets CoreCompile to output command line arguments 
@@ -35,7 +53,7 @@
         Name="_FSharpAnalyzerAfterBuild" 
         DependsOnTargets="_SetupFSharpAnalyzerProjectOptions;CoreCompile" 
         AfterTargets="AfterBuild" 
-        Condition="'$(RunAnalyzers)' == 'true'">
+        Condition="'$(_FSharpAnalyzers_RunDuringBuild)' == 'true'">
         <Error Condition="$(FSharpAnalyzersOtherFlags) == ''" Text="A property FSharpAnalyzersOtherFlags should exists with all the analyzer cli arguments!" />
         <PropertyGroup>
             <!-- 

--- a/src/FSharp.Analyzers.Build/build/FSharp.Analyzers.Build.targets
+++ b/src/FSharp.Analyzers.Build/build/FSharp.Analyzers.Build.targets
@@ -2,20 +2,20 @@
 
     <PropertyGroup>
         <!-- Used for dotnet host discovery -->
-        <FSharpAnalyzers_ExeHost Condition="'$(FSharpAnalyzers_ExeHost)' == ''">dotnet</FSharpAnalyzers_ExeHost>
+        <FSharpAnalyzersExeHost Condition="'$(FSharpAnalyzersExeHost)' == ''">dotnet</FSharpAnalyzersExeHost>
         <!-- Points to the dotnet tool or the FSharp.Analyzers.Cli.dll for debugging -->
-        <FSharpAnalyzers_Exe Condition="'$(FSharpAnalyzers_Exe)' == ''">fsharp-analyzers</FSharpAnalyzers_Exe>
+        <FSharpAnalyzersExe Condition="'$(FSharpAnalyzersExe)' == ''">fsharp-analyzers</FSharpAnalyzersExe>
         <!-- The build will continue even if the analyzer fails -->
-        <FSharpAnalyzers_ContinueOnError Condition="'$(FSharpAnalyzers_ContinueOnError)' == ''">true</FSharpAnalyzers_ContinueOnError>
-        <_FSharpAnalyzers_ProjectOptions>--project &quot;$(MSBuildProjectFile)&quot;</_FSharpAnalyzers_ProjectOptions>
+        <FSharpAnalyzersContinueOnError Condition="'$(FSharpAnalyzersContinueOnError)' == ''">true</FSharpAnalyzersContinueOnError>
+        <_FSharpAnalyzersProjectOptions>--project &quot;$(MSBuildProjectFile)&quot;</_FSharpAnalyzersProjectOptions>
     </PropertyGroup>
 
     <Target Name="_AnalyzeFSharpProject">
         <Error Condition="$(FSharpAnalyzersOtherFlags) == ''" Text="A property FSharpAnalyzersOtherFlags should exists with all the analyzer cli arguments!" />
         <Exec
-                ContinueOnError="$(FSharpAnalyzers_ContinueOnError)"
+                ContinueOnError="$(FSharpAnalyzersContinueOnError)"
                 IgnoreExitCode="true"
-                Command="$(FSharpAnalyzers_ExeHost) $(FSharpAnalyzers_Exe) $(_FSharpAnalyzers_ProjectOptions) $(FSharpAnalyzersOtherFlags)" />
+                Command="$(FSharpAnalyzersExeHost) $(FSharpAnalyzersExe) $(_FSharpAnalyzersProjectOptions) $(FSharpAnalyzersOtherFlags)" />
     </Target>
 
     <Target Name="AnalyzeFSharpProject" DependsOnTargets="_AnalyzeFSharpProject" />
@@ -29,8 +29,8 @@
             RunAnalyzers:  It takes precedence over RunAnalyzersDuringBuild
         -->
         <PropertyGroup>
-            <_FSharpAnalyzers_RunDuringBuild Condition="'$(RunAnalyzersDuringBuild)' != ''">$(RunAnalyzersDuringBuild)</_FSharpAnalyzers_RunDuringBuild>
-            <_FSharpAnalyzers_RunDuringBuild Condition="'$(RunAnalyzers)' != ''">$(RunAnalyzers)</_FSharpAnalyzers_RunDuringBuild>
+            <_FSharpAnalyzersRunDuringBuild Condition="'$(RunAnalyzersDuringBuild)' != ''">$(RunAnalyzersDuringBuild)</_FSharpAnalyzersRunDuringBuild>
+            <_FSharpAnalyzersRunDuringBuild Condition="'$(RunAnalyzers)' != ''">$(RunAnalyzers)</_FSharpAnalyzersRunDuringBuild>
         </PropertyGroup>
     </Target>
 
@@ -38,7 +38,7 @@
         Name="_SetupFSharpAnalyzerProjectOptions" 
         DependsOnTargets="_FSharpAnalyzersDetermineRunAnalyzersValues"
         BeforeTargets="CoreCompile" 
-        Condition="'$(_FSharpAnalyzers_RunDuringBuild)' == 'true'">
+        Condition="'$(_FSharpAnalyzersRunDuringBuild)' == 'true'">
         <PropertyGroup>
             <!-- 
                 Required for F# Targets CoreCompile to output command line arguments 
@@ -53,20 +53,20 @@
         Name="_FSharpAnalyzerAfterBuild" 
         DependsOnTargets="_SetupFSharpAnalyzerProjectOptions;CoreCompile" 
         AfterTargets="AfterBuild" 
-        Condition="'$(_FSharpAnalyzers_RunDuringBuild)' == 'true'">
+        Condition="'$(_FSharpAnalyzersRunDuringBuild)' == 'true'">
         <Error Condition="$(FSharpAnalyzersOtherFlags) == ''" Text="A property FSharpAnalyzersOtherFlags should exists with all the analyzer cli arguments!" />
         <PropertyGroup>
             <!-- 
                 If FscCommandLineArgs is empty, then CoreCompile did not run, we'll try to skip running the analyzer if this wasn't explicitly set to true
             -->
-            <FSharpAnalyzers_AlwaysRunAfterBuild Condition="'$(FSharpAnalyzers_AlwaysRunAfterBuild)' == '' and '@(FscCommandLineArgs->Count())' != '0'">true</FSharpAnalyzers_AlwaysRunAfterBuild>
+            <FSharpAnalyzersAlwaysRunAfterBuild Condition="'$(FSharpAnalyzersAlwaysRunAfterBuild)' == '' and '@(FscCommandLineArgs->Count())' != '0'">true</FSharpAnalyzersAlwaysRunAfterBuild>
             <!-- We'll try to use FscCommandLineArgs- to speed up analyzer execution since this skips requiring a design-time build -->
-            <_FSharpAnalyzers_ProjectOptions Condition="'@(FscCommandLineArgs->Count())' != '0'">--fsc-args &quot;@(FscCommandLineArgs)&quot;</_FSharpAnalyzers_ProjectOptions>
+            <_FSharpAnalyzersProjectOptions Condition="'@(FscCommandLineArgs->Count())' != '0'">--fsc-args &quot;@(FscCommandLineArgs)&quot;</_FSharpAnalyzersProjectOptions>
         </PropertyGroup>
         <Exec
-                ContinueOnError="$(FSharpAnalyzers_ContinueOnError)"
-                Condition="'$(FSharpAnalyzers_AlwaysRunAfterBuild)' == 'true'"
-                Command="$(FSharpAnalyzers_ExeHost) $(FSharpAnalyzers_Exe) $(_FSharpAnalyzers_ProjectOptions) $(FSharpAnalyzersOtherFlags)" />
+                ContinueOnError="$(FSharpAnalyzersContinueOnError)"
+                Condition="'$(FSharpAnalyzersAlwaysRunAfterBuild)' == 'true'"
+                Command="$(FSharpAnalyzersExeHost) $(FSharpAnalyzersExe) $(_FSharpAnalyzersProjectOptions) $(FSharpAnalyzersOtherFlags)" />
     </Target>
 
     <Target Name="FSharpAnalyzerAfterBuild" DependsOnTargets="_FSharpAnalyzerAfterBuild"/>


### PR DESCRIPTION
This kind of revitalizes https://github.com/ionide/FSharp.Analyzers.SDK/pull/164, but this takes a slightly different approach.

- Instead of trying to do a DesignTimeBuild within msbuild, it will try to run after a `CoreCompile`/`AfterBuild` target actually runs.
- This uses the `RunAnalyzer` or `RunAnalyzersDuringBuild` (see [Roslyn variables](https://learn.microsoft.com/en-us/visualstudio/code-quality/disable-code-analysis?view=vs-2022#net-framework-projects)) to determine if it should run or not.
- This will skip the `FsharpAnalyzerAfterBuild` target if `CoreCompile` does not produce FscArgs. However someone can use `FSharpAnalyzers_AlwaysRunAfterBuild` to always run after a build, still using Ionide.ProjInfo as before to do design time builds.