### PR TITLE
Add logging about System.Runtime load exceptions

### DIFF
--- a/src/FSharp.Analyzers.Cli/CustomLogging.fs
+++ b/src/FSharp.Analyzers.Cli/CustomLogging.fs
@@ -38,6 +38,10 @@ type CustomFormatter(options: IOptionsMonitor<CustomOptions>) as this =
         else
             this.WritePrefix(textWriter, logEntry.LogLevel)
             textWriter.WriteLine(message)
+            //  logEntry.Formatter doesn't actually write the exception so we need to do that ourselves
+            // https://github.com/dotnet/runtime/blob/2bcadad3045934b54672e626bbb6131f7d0a523c/src/libraries/Microsoft.Extensions.Logging.Console/src/SystemdConsoleFormatter.cs#L95-L101
+            if not (isNull logEntry.Exception) then
+                textWriter.WriteLine(logEntry.Exception.ToString())
 
     member private x.WritePrefix(textWriter: TextWriter, logLevel: LogLevel) =
         if not (isNull formatterOptions.TimestampFormat) then


### PR DESCRIPTION
Closes #245 

```bash
dotnet run -f net8.0 -- --project ../../samples/OptionAnalyzer/OptionAnalyzer.fsproj --analyzers-path ../../artifacts/bin/OptionAnalyzer/debug
[20:18:43.021] critical: FSharp.Analyzers.Cli could not find System.Runtime, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a. If you're using a preview version of the .NET SDK, you may need to set DOTNET_ROLL_FORWARD_TO_PRERELEASE=1 in your environment before running this tool.
System.IO.FileNotFoundException: Could not load file or assembly 'System.Runtime, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The system cannot find the file specified.
File name: 'System.Runtime, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
   at Ionide.ProjInfo.WorkspaceLoader.Ionide.ProjInfo.IWorkspaceLoader.LoadProjects(FSharpList`1 projects, FSharpList`1 customProperties, BinaryLogGeneration binaryLogs)
   at Program.loadProjects@176-3.Invoke(Unit unitVar) in C:\Users\jimmy\Repositories\public\TheAngryByrd\FSharp.Analyzers.SDK-wt\246-option-analyzer-editor-context\src\FSharp.Analyzers.Cli\Program.fs:line 177
   at Microsoft.FSharp.Control.AsyncPrimitives.CallThenInvoke[T,TResult](AsyncActivation`1 ctxt, TResult result1, FSharpFunc`2 part2) in D:\a\_work\1\s\src\FSharp.Core\async.fs:line 509
   at Program.loadProjects@173-9.Invoke(AsyncActivation`1 ctxt)
   at Program.loadProjects@168-12.Invoke(AsyncActivation`1 ctxt)
   at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction) in D:\a\_work\1\s\src\FSharp.Core\async.fs:line 112
--- End of stack trace from previous location ---
   at Microsoft.FSharp.Control.AsyncResult`1.Commit() in D:\a\_work\1\s\src\FSharp.Core\async.fs:line 453
   at Microsoft.FSharp.Control.AsyncPrimitives.QueueAsyncAndWaitForResultSynchronously[a](CancellationToken token, FSharpAsync`1 computation, FSharpOption`1 timeout) in D:\a\_work\1\s\src\FSharp.Core\async.fs:line 1138      
   at Microsoft.FSharp.Control.AsyncPrimitives.RunSynchronously[T](CancellationToken cancellationToken, FSharpAsync`1 computation, FSharpOption`1 timeout) in D:\a\_work\1\s\src\FSharp.Core\async.fs:line 1165
   at Microsoft.FSharp.Control.FSharpAsync.RunSynchronously[T](FSharpAsync`1 computation, FSharpOption`1 timeout, FSharpOption`1 cancellationToken) in D:\a\_work\1\s\src\FSharp.Core\async.fs:line 1514
   at Program.main(String[] argv) in C:\Users\jimmy\Repositories\public\TheAngryByrd\FSharp.Analyzers.SDK-wt\246-option-analyzer-editor-context\src\FSharp.Analyzers.Cli\Program.fs:line 834
   ```