### PR TITLE
Fix the path to the OptionsAnalyzer binary in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ F# analyzers are live, real-time, project based plugins that enables to diagnose
 2. Run the console application:
 
 ```shell
-dotnet run --project src\FSharp.Analyzers.Cli\FSharp.Analyzers.Cli.fsproj -- --project ./samples/OptionAnalyzer/OptionAnalyzer.fsproj --analyzers-path ./samples/OptionAnalyzer/bin/Release --verbosity d
+dotnet run --project src\FSharp.Analyzers.Cli\FSharp.Analyzers.Cli.fsproj -- --project ./samples/OptionAnalyzer/OptionAnalyzer.fsproj --analyzers-path ./artifacts/bin/OptionAnalyzer/release --verbosity d
 ```
 
 You can also set up a run configuration of FSharp.Analyzers.Cli in your favorite IDE using similar arguments. This also allows you to debug FSharp.Analyzers.Cli.


### PR DESCRIPTION
The build is using artifact output, so the binaries get put under ./artifacts rather than ./samples