### PR TITLE
Add NuGet login step for package publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,12 @@ jobs:
           version: ${{ steps.tag_name.outputs.current_version }}
           path: ./CHANGELOG.md
 
+      - name: Get NuGet Publishing Key
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: ${{secrets.NUGET_USER}}
+
       - name: Create Release
         uses: ncipollo/release-action@v1
         if: ${{ !contains(steps.tag_name.outputs.current_version, '-MsBuild') }}
@@ -49,4 +55,4 @@ jobs:
           prerelease: ${{ steps.changelog_reader.outputs.status == 'prereleased' }}
 
       - name: Push packages
-        run: dotnet nuget push "**/*.nupkg" -s "https://api.nuget.org/v3/index.json" -k  ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+        run: dotnet nuget push "**/*.nupkg" -s "https://api.nuget.org/v3/index.json" ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --skip-duplicate


### PR DESCRIPTION
This prevents us from having to rotate NuGet publishing keys, as one is retrieved on-demand.  Docs are at https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing#github-actions-setup.

I've added the NUGET_USER secret that points to the trusted publisher configuration. We do similar in FsAutoComplete and a few other repos already: https://github.com/ionide/FsAutoComplete/blob/main/.github/workflows/release.yml#L54-L61