### PR TITLE
Update release.yml with permissions for OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "v*"
 
+permissions:
+  id-token: write # needed to be able to do OIDC handshake for NuGet Trusted Publishing
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Added permissions for OIDC handshake and content access.

I missed this requirement when reading the docs at https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing#github-actions-setup