### PR TITLE
Update the checkout and setup-dotnet actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:  
           global-json-file: 'global.json'
            #  9.0.101 because of https://github.com/dotnet/fsharp/issues/18298#issuecomment-2655277169

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
           echo ::set-output name=current_version::${GITHUB_REF#refs/tags/v}
         shell: bash
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:  
           global-json-file: 'global.json'
           dotnet-version: |


### PR DESCRIPTION
There are warnings in the build about the current versions using the deprecated Node 20, so lets update them

ref

<img width="1150" height="94" alt="image" src="https://github.com/user-attachments/assets/de2a79ec-03f3-4eeb-8ff0-7d1f49baad69" />
