### PR TITLE
Update to FCS 43.12.400

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,8 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="CliWrap" Version="3.10.5" />
-    <PackageVersion Include="FSharp.Core" Version="[10.1.201]" />
-    <PackageVersion Include="FSharp.Compiler.Service" Version="43.12.201" />
+    <PackageVersion Include="FSharp.Core" Version="[10.1.400]" />
+    <PackageVersion Include="FSharp.Compiler.Service" Version="43.12.400" />
     <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.3.0" PrivateAssets="all" />
     <PackageVersion Include="McMaster.NETCore.Plugins" Version="2.0.0" />
     <PackageVersion Include="Argu" Version="6.2.5" />

--- a/src/FSharp.Analyzers.SDK/TASTCollecting.fs
+++ b/src/FSharp.Analyzers.SDK/TASTCollecting.fs
@@ -461,6 +461,11 @@ module TASTCollecting =
 
     let rec visitDeclaration (f: TypedTreeCollectorBase) d =
 
+        let shouldIgnoreExprType typeName =
+            match typeName with
+            | None -> false
+            | Some name -> Set.contains name exprTypesToIgnore
+
         match d with
         | FSharpImplementationFileDeclaration.Entity(e, subDecls) ->
             f.WalkEntity e subDecls
@@ -474,7 +479,7 @@ module TASTCollecting =
                 not v.IsCompilerGenerated
                 || not (Set.contains v.CompiledName membersToIgnore)
                 || not e.Type.IsAbbreviation
-                || not (Set.contains e.Type.BasicQualifiedName exprTypesToIgnore)
+                || not (shouldIgnoreExprType e.Type.BasicQualifiedName)
             then
                 f.WalkMemberOrFunctionOrValue v vs e
 


### PR DESCRIPTION
Supersedes https://github.com/ionide/FSharp.Analyzers.SDK/pull/307 (43.12.204 and 43.10.400 both contain the same breaking API change where FSharpType.BasicQualifiedName is now an Option)

refs https://github.com/ionide/FSharp.Analyzers.SDK/pull/311 which updates the whole thing to .NET 10 and the 10.0.400 SDK