### PR TITLE
Minor code cleanup: Hoist the property-splitting Regex out of the map.

### DIFF
--- a/src/FSharp.Analyzers.Cli/MsBuildProperties.fs
+++ b/src/FSharp.Analyzers.Cli/MsBuildProperties.fs
@@ -6,12 +6,12 @@ open System.Text.RegularExpressions
 open Argu
 open Microsoft.Extensions.Logging
 
-/// If multiple MSBuild properties are given in one -p flag like -p:prop1="val1a;val1b;val1c";prop2="1;2;3";prop3=val3
-/// argu will think it means prop1 has the value: "val1a;val1b;val1c";prop2="1;2;3";prop3=val3
-/// so this function expands the value into multiple key-value properties
 // built once for every property, not per element
 let private multiPropertyRegex = Regex(";([a-z,A-Z,0-9,_,-]*)=")
 
+/// If multiple MSBuild properties are given in one -p flag like -p:prop1="val1a;val1b;val1c";prop2="1;2;3";prop3=val3
+/// argu will think it means prop1 has the value: "val1a;val1b;val1c";prop2="1;2;3";prop3=val3
+/// so this function expands the value into multiple key-value properties
 let expandMultiProperties (logger: ILogger) (properties: (string * string) list) =
     properties
     |> List.map (fun (k, v) ->

--- a/src/FSharp.Analyzers.Cli/MsBuildProperties.fs
+++ b/src/FSharp.Analyzers.Cli/MsBuildProperties.fs
@@ -9,14 +9,16 @@ open Microsoft.Extensions.Logging
 /// If multiple MSBuild properties are given in one -p flag like -p:prop1="val1a;val1b;val1c";prop2="1;2;3";prop3=val3
 /// argu will think it means prop1 has the value: "val1a;val1b;val1c";prop2="1;2;3";prop3=val3
 /// so this function expands the value into multiple key-value properties
+// built once for every property, not per element
+let private multiPropertyRegex = Regex(";([a-z,A-Z,0-9,_,-]*)=")
+
 let expandMultiProperties (logger: ILogger) (properties: (string * string) list) =
     properties
     |> List.map (fun (k, v) ->
         if not (v.Contains('=')) then // no multi properties given to expand
             [ (k, v) ]
         else
-            let regex = Regex(";([a-z,A-Z,0-9,_,-]*)=")
-            let splits = regex.Split(v)
+            let splits = multiPropertyRegex.Split(v)
 
             [
                 yield (k, splits[0])


### PR DESCRIPTION
Hoist the property-splitting Regex out of the map.