### PR TITLE
Type check scripts against the SDK reference assemblies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- [The typed tree of a `.fsx` passed to `--script` no longer omits most of the script](https://github.com/ionide/FSharp.Analyzers.SDK/issues/332). Scripts were resolved against the .NET Framework reference assemblies, so `FSharp.Core` failed to load and everything coming from it (`printfn`, `string`, `int`, ...) became an error recovery node that typed tree analyzers could not see.
+
+### Added
+
+- Type check errors in a project or script are now reported as a warning, instead of silently producing fewer analyzer messages.
+
 ## [0.39.0] - 2026-09-10
 
 ### Added

--- a/src/FSharp.Analyzers.Cli/Analysis.fs
+++ b/src/FSharp.Analyzers.Cli/Analysis.fs
@@ -3,6 +3,7 @@ module FSharp.Analyzers.Cli.Analysis
 open System
 open System.IO
 open FSharp.Compiler.CodeAnalysis
+open FSharp.Compiler.Diagnostics
 open FSharp.Compiler.Text
 open GlobExpressions
 open Microsoft.Extensions.Logging
@@ -23,6 +24,21 @@ let runProject
         logger.LogInformation("Checking project {0}", fsharpOptions.ProjectFileName)
         let! checkProjectResults = checker.ParseAndCheckProject(fsharpOptions)
         let analyzerOptions = BackgroundCompilerOptions fsharpOptions
+
+        // A type error is replaced with an error recovery node in the typed tree, so any analyzer looking
+        // at that part of the tree silently reports nothing. Surface the errors instead of looking clean.
+        let typeCheckErrors =
+            checkProjectResults.Diagnostics
+            |> Array.filter (fun d -> d.Severity = FSharpDiagnosticSeverity.Error)
+
+        if not (Array.isEmpty typeCheckErrors) then
+            logger.LogWarning(
+                "{0} did not type check, results may be incomplete. Analyzers using the typed tree cannot see code that failed to type check.",
+                fsharpOptions.ProjectFileName
+            )
+
+            for d in typeCheckErrors do
+                logger.LogWarning("{0}: {1}", d.Range, d.Message)
 
         let! messagesPerAnalyzer =
             fsharpOptions.SourceFiles

--- a/src/FSharp.Analyzers.Cli/ProjectLoading.fs
+++ b/src/FSharp.Analyzers.Cli/ProjectLoading.fs
@@ -149,7 +149,17 @@ let loadScripts (logger: ILogger) (checker: FSharpChecker) (scripts: string list
 
             let sourceText = SourceText.ofString fileContent
             // GetProjectOptionsFromScript cannot be run in parallel, it is not thread-safe.
-            let! options, diagnostics = checker.GetProjectOptionsFromScript(script, sourceText)
+            let! options, diagnostics =
+                checker.GetProjectOptionsFromScript(
+                    script,
+                    sourceText,
+                    // Without these, the script is resolved against the .NET Framework reference assemblies.
+                    // FSharp.Core then fails to load and every construct that comes from it (printfn, string, int, ...)
+                    // becomes an error-recovery node in the typed tree, which analyzers silently skip.
+                    // See https://github.com/ionide/FSharp.Analyzers.SDK/issues/332
+                    assumeDotNetFramework = false,
+                    useSdkRefs = true
+                )
 
             if not (List.isEmpty diagnostics) then
                 diagnostics

--- a/tests/FSharp.Analyzers.Cli.Tests/FSharp.Analyzers.Cli.Tests.fsproj
+++ b/tests/FSharp.Analyzers.Cli.Tests/FSharp.Analyzers.Cli.Tests.fsproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="SeverityMappingTests.fs" />
     <Compile Include="MsBuildPropertiesTests.fs" />
+    <Compile Include="ScriptLoadingTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/FSharp.Analyzers.Cli.Tests/ScriptLoadingTests.fs
+++ b/tests/FSharp.Analyzers.Cli.Tests/ScriptLoadingTests.fs
@@ -1,0 +1,83 @@
+module FSharp.Analyzers.Cli.Tests.ScriptLoadingTests
+
+open System.IO
+open NUnit.Framework
+open Microsoft.Extensions.Logging.Abstractions
+open FSharp.Compiler.Diagnostics
+open FSharp.Compiler.Symbols
+open FSharp.Analyzers.SDK
+open FSharp.Analyzers.SDK.TASTCollecting
+open FSharp.Analyzers.Cli.ProjectLoading
+
+/// Writes the source to a temporary script, type checks it the way the CLI does and
+/// returns the project diagnostics together with the typed tree of the script.
+let private checkScript (source: string) =
+    let script = Path.Combine(Path.GetTempPath(), $"%s{Path.GetRandomFileName()}.fsx")
+
+    File.WriteAllText(script, source)
+
+    try
+        let checker = Utils.createFCS None
+
+        let options =
+            loadScripts NullLogger.Instance checker [ script ]
+            |> Async.RunSynchronously
+            |> Array.exactlyOne
+
+        let projectResults =
+            checker.ParseAndCheckProject options
+            |> Async.RunSynchronously
+
+        let _, fileResults =
+            checker.GetBackgroundCheckResultsForFileInProject(script, options)
+            |> Async.RunSynchronously
+
+        projectResults.Diagnostics, fileResults.ImplementationFile
+    finally
+        File.Delete script
+
+/// Collects the full names of every call in the typed tree.
+let private calls (typedTree: FSharpImplementationFileContents option) =
+    let names = ResizeArray()
+
+    let collector =
+        { new TypedTreeCollectorBase() with
+            override _.WalkCall _ mfv _ _ _ _ = names.Add mfv.FullName
+        }
+
+    typedTree
+    |> Option.iter (walkTast collector)
+
+    List.ofSeq names
+
+[<Test>]
+let ``a script type checks against the sdk reference assemblies`` () =
+    let diagnostics, _ = checkScript "printfn \"%b\" (\"foo\".EndsWith(\"p\"))\n"
+
+    let errors =
+        diagnostics
+        |> Array.filter (fun d -> d.Severity = FSharpDiagnosticSeverity.Error)
+        |> Array.map (fun d -> d.Message)
+
+    Assert.That(errors, Is.Empty)
+
+// A construct that fails to type check is replaced with an error recovery node in the typed tree,
+// which leaves nothing for a typed tree analyzer to match on.
+// See https://github.com/ionide/FSharp.Analyzers.SDK/issues/332
+[<Test>]
+let ``the typed tree of a script contains bare top-level expressions`` () =
+    let _, typedTree = checkScript "printfn \"%b\" (\"foo\".EndsWith(\"p\"))\n"
+
+    Assert.That(calls typedTree, Does.Contain "System.String.EndsWith")
+
+[<Test>]
+let ``the typed tree of a script contains top-level do expressions`` () =
+    let _, typedTree = checkScript "do printfn \"%b\" (\"foo\".EndsWith(\"p\"))\n"
+
+    Assert.That(calls typedTree, Does.Contain "System.String.EndsWith")
+
+[<Test>]
+let ``the typed tree of a script contains the body of a top-level binding`` () =
+    let _, typedTree = checkScript "let f (y: int) = string y\n"
+
+    Assert.That(calls typedTree, Does.Contain "Microsoft.FSharp.Core.Operators.string")


### PR DESCRIPTION
GetProjectOptionsFromScript defaults to assumeDotNetFramework = true, so a .fsx passed with --script was resolved against the .NET Framework reference assemblies. FSharp.Core then failed to load and everything coming from it (printfn, string, int, ...) was undefined. Those constructs end up as error recovery nodes in the typed tree, which analyzers cannot match on, so a --script run silently reported nothing for most of the script.

Also warn when a project or script does not type check, so a run that can only cover part of the code no longer looks clean.

Fixes #332