### PR TITLE
Reference the fsi settings assembly when loading a script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.39.1] - 2026-09-12
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - [The typed tree of a `.fsx` passed to `--script` no longer omits most of the script](https://github.com/ionide/FSharp.Analyzers.SDK/issues/332). Scripts were resolved against the .NET Framework reference assemblies, so `FSharp.Core` failed to load and everything coming from it (`printfn`, `string`, `int`, ...) became an error recovery node that typed tree analyzers could not see.
+- [A `.fsx` passed to `--script` can use the `fsi` object](https://github.com/ionide/FSharp.Analyzers.SDK/issues/334), such as `fsi.CommandLineArgs`. `FSharp.Compiler.Interactive.Settings.dll`, which `dotnet fsi` references implicitly, was not referenced, so every use of `fsi` failed to type check and took the surrounding expressions with it.
 
 ### Added
 

--- a/src/FSharp.Analyzers.Cli/Program.fs
+++ b/src/FSharp.Analyzers.Cli/Program.fs
@@ -329,7 +329,7 @@ let main argv =
 
                             exit (int ExitErrorCodes.InvalidProjectArguments)
 
-                    let scriptOptions = loadScripts logger checker scripts
+                    let scriptOptions = loadScripts logger toolsPath checker scripts
 
                     for projPath in projects do
                         if not (File.Exists(projPath)) then

--- a/src/FSharp.Analyzers.Cli/ProjectLoading.fs
+++ b/src/FSharp.Analyzers.Cli/ProjectLoading.fs
@@ -7,6 +7,7 @@ open FSharp.Compiler.Text
 open GlobExpressions
 open Microsoft.Extensions.Logging
 open Ionide.ProjInfo
+open Ionide.ProjInfo.Types
 
 /// <summary>Runs MSBuild to create FSharpProjectOptions based on the projPaths.</summary>
 /// <returns>Returns only the FSharpProjectOptions based on the projPaths and not any referenced projects.</returns>
@@ -138,8 +139,45 @@ let resolveScriptPaths (cwd: DirectoryInfo) (scriptGlobs: string list) =
         |> Seq.toList
     )
 
+/// <summary>
+/// Locates the assembly that gives a script its <c>fsi</c> object (<c>fsi.CommandLineArgs</c>, <c>fsi.EventLoop</c>, ...).
+/// </summary>
+/// <remarks>
+/// <c>dotnet fsi</c> references FSharp.Compiler.Interactive.Settings.dll implicitly, and FCS looks for it next to its
+/// own binaries. For a dotnet tool those are the tool's own files, which do not include it, so every use of
+/// <c>fsi</c> fails to type check and takes the surrounding expressions down with it through error recovery.
+/// The assembly ships in the <c>FSharp</c> folder of the SDK that toolsPath points into.
+/// See https://github.com/ionide/FSharp.Analyzers.SDK/issues/334
+/// </remarks>
+let fsiSettingsFlags (logger: ILogger) (ToolsPath toolsPath) =
+    // Init.init resolves toolsPath to the MSBuild.dll of a single SDK version.
+    let assembly =
+        Path.Combine(
+            Path.GetDirectoryName(toolsPath: string),
+            "FSharp",
+            "FSharp.Compiler.Interactive.Settings.dll"
+        )
+
+    if File.Exists assembly then
+        [| $"-r:%s{assembly}" |]
+    else
+        logger.LogWarning("Could not find {0}. Scripts using `fsi` will not type check.", assembly)
+
+        Array.empty
+
 /// Creates FSharpProjectOptions for each script.
-let loadScripts (logger: ILogger) (checker: FSharpChecker) (scripts: string list) =
+let loadScripts
+    (logger: ILogger)
+    (toolsPath: ToolsPath)
+    (checker: FSharpChecker)
+    (scripts: string list)
+    =
+    let otherFlags =
+        if List.isEmpty scripts then
+            Array.empty
+        else
+            fsiSettingsFlags logger toolsPath
+
     scripts
     |> List.map (fun script ->
         async {
@@ -158,7 +196,8 @@ let loadScripts (logger: ILogger) (checker: FSharpChecker) (scripts: string list
                     // becomes an error-recovery node in the typed tree, which analyzers silently skip.
                     // See https://github.com/ionide/FSharp.Analyzers.SDK/issues/332
                     assumeDotNetFramework = false,
-                    useSdkRefs = true
+                    useSdkRefs = true,
+                    otherFlags = otherFlags
                 )
 
             if not (List.isEmpty diagnostics) then

--- a/tests/FSharp.Analyzers.Cli.Tests/ScriptLoadingTests.fs
+++ b/tests/FSharp.Analyzers.Cli.Tests/ScriptLoadingTests.fs
@@ -1,5 +1,6 @@
 module FSharp.Analyzers.Cli.Tests.ScriptLoadingTests
 
+open System
 open System.IO
 open NUnit.Framework
 open Microsoft.Extensions.Logging.Abstractions
@@ -8,6 +9,10 @@ open FSharp.Compiler.Symbols
 open FSharp.Analyzers.SDK
 open FSharp.Analyzers.SDK.TASTCollecting
 open FSharp.Analyzers.Cli.ProjectLoading
+open Ionide.ProjInfo
+
+let private toolsPath =
+    lazy (Init.init (DirectoryInfo Environment.CurrentDirectory) None)
 
 /// Writes the source to a temporary script, type checks it the way the CLI does and
 /// returns the project diagnostics together with the typed tree of the script.
@@ -20,7 +25,7 @@ let private checkScript (source: string) =
         let checker = Utils.createFCS None
 
         let options =
-            loadScripts NullLogger.Instance checker [ script ]
+            loadScripts NullLogger.Instance toolsPath.Value checker [ script ]
             |> Async.RunSynchronously
             |> Array.exactlyOne
 
@@ -81,3 +86,24 @@ let ``the typed tree of a script contains the body of a top-level binding`` () =
     let _, typedTree = checkScript "let f (y: int) = string y\n"
 
     Assert.That(calls typedTree, Does.Contain "Microsoft.FSharp.Core.Operators.string")
+
+// `dotnet fsi` references FSharp.Compiler.Interactive.Settings.dll implicitly, so a script may use `fsi`
+// without saying anything. FCS does not find that assembly from a dotnet tool on its own.
+// See https://github.com/ionide/FSharp.Analyzers.SDK/issues/334
+[<Test>]
+let ``a script can use the fsi object`` () =
+    let diagnostics, _ = checkScript "let args: string array = fsi.CommandLineArgs\n"
+
+    let errors =
+        diagnostics
+        |> Array.filter (fun d -> d.Severity = FSharpDiagnosticSeverity.Error)
+        |> Array.map (fun d -> d.Message)
+
+    Assert.That(errors, Is.Empty)
+
+[<Test>]
+let ``the typed tree of a script contains a call on the fsi object`` () =
+    let _, typedTree =
+        checkScript "printfn \"%b\" (fsi.CommandLineArgs[0].EndsWith(\"p\"))\n"
+
+    Assert.That(calls typedTree, Does.Contain "System.String.EndsWith")


### PR DESCRIPTION
A script may use the `fsi` object (fsi.CommandLineArgs, fsi.EventLoop, ...)
without saying anything, because `dotnet fsi` references
FSharp.Compiler.Interactive.Settings.dll implicitly. FCS looks for that
assembly next to its own binaries, which for a dotnet tool are the tool's
own files, so the reference silently dropped and every use of `fsi` failed
to type check. Error recovery then took the surrounding expressions with
it, leaving analyzers nothing to match on.

Pass `-r:` for the copy that ships in the FSharp folder of the SDK that
toolsPath points into, so scripts resolve `fsi` against the same SDK that
MSBuild loads projects with.

Fixes #334