### PR TITLE
Accumulate repeated list flags instead of keeping the last one

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,14 +3,14 @@
   "isRoot": true,
   "tools": {
     "fsdocs-tool": {
-      "version": "22.2.0",
+      "version": "23.0.0-alpha.2",
       "commands": [
         "fsdocs"
       ],
       "rollForward": false
     },
     "fantomas": {
-      "version": "8.0.0-beta-001",
+      "version": "8.0.0-beta-003",
       "commands": [
         "fantomas"
       ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.39.2] - 2026-09-12
+
+### Fixed
+
+- [A repeated `--script` flag no longer silently drops all but the last occurrence](https://github.com/ionide/FSharp.Analyzers.SDK/issues/336). Every list-valued flag now accumulates the way `--project` and `--analyzers-path` already did, so `--script a.fsx --script b.fsx` means the same as `--script a.fsx b.fsx`. Previously a caller that built its arguments in a loop analyzed a subset of what it asked for and still got a clean run reported. The `--treat-as-*`, `--exclude-files`, `--include-files`, `--exclude-analyzers` and `--include-analyzers` flags rejected a repeat outright and now accumulate too.
+
 ## [0.39.1] - 2026-09-12
 
 ### Fixed

--- a/src/FSharp.Analyzers.Cli/Arguments.fs
+++ b/src/FSharp.Analyzers.Cli/Arguments.fs
@@ -11,14 +11,14 @@ type Arguments =
     | [<Unique; AltCommandLine("-r")>] Runtime of string
     | [<Unique; AltCommandLine("-a")>] Arch of string
     | [<Unique>] Os of string
-    | [<Unique>] Treat_As_Info of string list
-    | [<Unique>] Treat_As_Hint of string list
-    | [<Unique>] Treat_As_Warning of string list
-    | [<Unique>] Treat_As_Error of string list
-    | [<Unique>] Exclude_Files of string list
-    | [<Unique>] Include_Files of string list
-    | [<Unique>] Exclude_Analyzers of string list
-    | [<Unique>] Include_Analyzers of string list
+    | Treat_As_Info of string list
+    | Treat_As_Hint of string list
+    | Treat_As_Warning of string list
+    | Treat_As_Error of string list
+    | Exclude_Files of string list
+    | Include_Files of string list
+    | Exclude_Analyzers of string list
+    | Include_Analyzers of string list
     | [<Unique>] Report of string
     | [<Unique>] FSC_Args of string
     | [<Unique>] FSC_Args_File of string
@@ -68,3 +68,15 @@ type Arguments =
                 "Format in which to write analyzer results to stdout. The available options are: default, github."
             | BinLog_Path(_) ->
                 "Path to a directory where MSBuild binary logs (binlog) will be written. You can use https://msbuildlog.com/ to view them."
+
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module Arguments =
+
+    /// Argu's `GetResult` only returns the last occurrence of a repeated flag and silently drops the earlier ones.
+    /// List-valued flags accumulate instead, so `--script a --script b` means the same as `--script a b`.
+    let getAll
+        (results: ParseResults<Arguments>)
+        (argument: Quotations.Expr<string list -> Arguments>)
+        =
+        results.GetResults argument
+        |> List.concat

--- a/src/FSharp.Analyzers.Cli/Program.fs
+++ b/src/FSharp.Analyzers.Cli/Program.fs
@@ -90,8 +90,10 @@ let main argv =
         exit (int ExitErrorCodes.UnhandledException)
     )
 
+    let getAllResults argument = Arguments.getAll results argument
+
     let parseSeverityCodes (argument: Quotations.Expr<string list -> Arguments>) =
-        results.GetResult(argument, [])
+        getAllResults argument
         |> List.distinct
         |> List.map (fun input ->
             match SeverityCode.tryParse input with
@@ -132,9 +134,7 @@ let main argv =
         factory.Dispose() // Flush any logs https://github.com/dotnet/extensions/issues/2395
         exit (int ExitErrorCodes.AnalyzerListedMultipleTimesInTreatAsSeverity)
 
-    let projOpts =
-        results.GetResults <@ Project @>
-        |> List.concat
+    let projOpts = getAllResults <@ Project @>
 
     let fscArgs = results.TryGetResult <@ FSC_Args @>
     let fscArgsFile = results.TryGetResult <@ FSC_Args_File @>
@@ -159,10 +159,10 @@ let main argv =
         Directory.GetCurrentDirectory()
         |> DirectoryInfo
 
-    let scripts = resolveScriptPaths cwd (results.GetResult(<@ Script @>, []))
+    let scripts = resolveScriptPaths cwd (getAllResults <@ Script @>)
 
     let exclInclFiles =
-        let excludeFiles = results.GetResult(<@ Exclude_Files @>, [])
+        let excludeFiles = getAllResults <@ Exclude_Files @>
 
         logger.LogInformation(
             "Exclude Files: [{0}]",
@@ -172,7 +172,7 @@ let main argv =
 
         let excludeFiles = excludeFiles |> List.map Glob
 
-        let includeFiles = results.GetResult(<@ Include_Files @>, [])
+        let includeFiles = getAllResults <@ Include_Files @>
 
         logger.LogInformation(
             "Include Files: [{0}]",
@@ -214,8 +214,7 @@ let main argv =
         )
 
     let analyzersPaths =
-        results.GetResults(<@ Analyzers_Path @>)
-        |> List.concat
+        getAllResults <@ Analyzers_Path @>
         |> function
             | [] -> [ "packages/Analyzers" ]
             | paths -> paths
@@ -229,8 +228,8 @@ let main argv =
     logger.LogInformation("Loading analyzers from {0}", (String.concat ", " analyzersPaths))
 
     let exclInclAnalyzers =
-        let excludeAnalyzers = results.GetResult(<@ Exclude_Analyzers @>, [])
-        let includeAnalyzers = results.GetResult(<@ Include_Analyzers @>, [])
+        let excludeAnalyzers = getAllResults <@ Exclude_Analyzers @>
+        let includeAnalyzers = getAllResults <@ Include_Analyzers @>
 
         match excludeAnalyzers, includeAnalyzers with
         | e, [] ->

--- a/tests/FSharp.Analyzers.Cli.Tests/ArgumentsTests.fs
+++ b/tests/FSharp.Analyzers.Cli.Tests/ArgumentsTests.fs
@@ -1,0 +1,85 @@
+module FSharp.Analyzers.Cli.Tests.ArgumentsTests
+
+open Argu
+open NUnit.Framework
+open FSharp.Analyzers.Cli
+
+let private parser = ArgumentParser.Create<Arguments>()
+
+let private parse argv =
+    parser.ParseCommandLine(inputs = argv, raiseOnUsage = true)
+
+[<Test>]
+let ``a single list flag keeps all its values`` () =
+    let results =
+        parse
+            [|
+                "--script"
+                "a.fsx"
+                "b.fsx"
+            |]
+
+    Assert.That(
+        Arguments.getAll results <@ Script @>,
+        Is.EqualTo
+            [
+                "a.fsx"
+                "b.fsx"
+            ]
+    )
+
+[<Test>]
+let ``a repeated list flag accumulates instead of keeping the last occurrence`` () =
+    let results =
+        parse
+            [|
+                "--script"
+                "a.fsx"
+                "--script"
+                "b.fsx"
+            |]
+
+    Assert.That(
+        Arguments.getAll results <@ Script @>,
+        Is.EqualTo
+            [
+                "a.fsx"
+                "b.fsx"
+            ]
+    )
+
+[<Test>]
+let ``an absent list flag yields an empty list`` () =
+    let results =
+        parse
+            [|
+                "--project"
+                "a.fsproj"
+            |]
+
+    Assert.That(Arguments.getAll results <@ Script @>, Is.Empty)
+
+/// Every list-valued flag is expected to behave the same, see
+/// https://github.com/ionide/FSharp.Analyzers.SDK/issues/336
+[<TestCase("--project")>]
+[<TestCase("--script")>]
+[<TestCase("--analyzers-path")>]
+[<TestCase("--treat-as-info")>]
+[<TestCase("--treat-as-hint")>]
+[<TestCase("--treat-as-warning")>]
+[<TestCase("--treat-as-error")>]
+[<TestCase("--exclude-files")>]
+[<TestCase("--include-files")>]
+[<TestCase("--exclude-analyzers")>]
+[<TestCase("--include-analyzers")>]
+let ``every list flag can be repeated`` (flag: string) =
+    let results =
+        parse
+            [|
+                flag
+                "one"
+                flag
+                "two"
+            |]
+
+    Assert.That(results.GetAllResults(), Has.Exactly(2).Items)

--- a/tests/FSharp.Analyzers.Cli.Tests/FSharp.Analyzers.Cli.Tests.fsproj
+++ b/tests/FSharp.Analyzers.Cli.Tests/FSharp.Analyzers.Cli.Tests.fsproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="ArgumentsTests.fs" />
     <Compile Include="SeverityMappingTests.fs" />
     <Compile Include="MsBuildPropertiesTests.fs" />
     <Compile Include="ScriptLoadingTests.fs" />


### PR DESCRIPTION
Only --project and --analyzers-path read every occurrence of their flag. --script used Argu's GetResult, which returns the last occurrence and silently discards the earlier ones, so a caller that built its arguments in a loop analyzed a subset of what it asked for, said nothing about the rest and exited 0. That reads as a clean run.

The other list flags (--treat-as-*, --exclude-files, --include-files, --exclude-analyzers, --include-analyzers) were marked Unique and rejected a repeat outright. Loud rather than silent, but still a third meaning for the same shape of argument.

Drop Unique from the list-valued cases and route them all through a shared Arguments.getAll helper, so `--script a.fsx --script b.fsx` means the same as `--script a.fsx b.fsx` for every one of them.

Also bumps fantomas and fsdocs-tool.

Fixes #336